### PR TITLE
1.9.4a

### DIFF
--- a/addons-page1.opy
+++ b/addons-page1.opy
@@ -13,7 +13,7 @@ rule "Pre-set control map portal | function | toggled via workshop":
     @Event eachPlayer
     @Condition PortalOn
     @Condition eventPlayer.InvincibleToggle or not eventPlayer.NotOnLastCp
-    @Condition len(PortalLoc) != null
+    @Condition PortalLoc != []
     @Condition any([distance(eventPlayer.getPosition() + vect(0,0.2,0),i) < 1.4 for i in PortalLoc])
     if PortalDest[PortalLoc.index(sorted(PortalLoc, lambda i: distance(eventPlayer, i))[0])] != vect(0,0,0):
         eventPlayer.teleport(
@@ -22,7 +22,7 @@ rule "Pre-set control map portal | function | toggled via workshop":
    
 rule "Custom portals | function":
     @Event eachPlayer
-    @Condition len(eventPlayer.PortalStart_Cache) > 0
+    @Condition eventPlayer.PortalStart_Cache != []
     @Condition [i for i in eventPlayer.PortalStart_Cache if distance(i, eventPlayer.getPosition() + vect(0,0.2,0)) < portaldistance]
     #@Condition any([distance(eventPlayer.getPosition() + vect(0, 0.2, 0), ent) < portaldistance for ent in eventPlayer.PortalStart_Cache]) == true
 
@@ -213,7 +213,7 @@ rule "Little destructo - fence breaker":
   
     # handle exceptions (looking at you new queen street)
     MapVectorArray = [vect(8.276, 4.113, 15.261), vect(-8.319, 2.624, 14.245), vect(0.006, 4.821, 18.513)]
-    while len(MapVectorArray) > 0: 
+    while len(MapVectorArray): 
         # same as other projectile before
         createProjectile(
             Projectile.ORB,  

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -352,8 +352,7 @@ rule "Custom Orb Script":
 rule "Ledge Grab Patch 1.3":
     @Disabled
     @Event eachPlayer
-    #Script by LulledLion
-    #08/28/24
+    #Script by LulledLion 08/28/24
     @Condition eventPlayer.isAlive() == true
     @Condition eventPlayer.isOnGround() == false
     @Condition eventPlayer.DoubleUsed == (eventPlayer.getCurrentHero() == Hero.GENJI)
@@ -368,12 +367,15 @@ rule "Ledge Grab Patch 1.3":
     eventPlayer.startForcingButton(Button.JUMP)
     waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
     eventPlayer.stopForcingButton(Button.JUMP)
-    #Ledge Grab Loop
+    #Ledge Grab loop
     while not eventPlayer.isOnGround():
-        #Multi-Climb | Refresh Bhop
+        #Multi-Climb | Create Bhop
         if not eventPlayer.isOnWall():
             eventPlayer.startForcingButton(Button.JUMP)
             wait(false)
             eventPlayer.stopForcingButton(Button.JUMP)
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        #Create Bhop fixed? TODO Narrow Timing
+        #Helpful Debuggers Dark Moisty LostJe Amwaj Iloveto M4rtian
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.CROUCH), 0.096)

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -349,13 +349,15 @@ rule "Custom Orb Script":
         eventPlayer.setMoveSpeed(250)
         smallMessage(eventPlayer," zooom")
 
-rule "Ledge Grab Patch 1.4":
+rule "Ledge Grab Patch 1.5":
     @Disabled
     @Event eachPlayer
-    #Script by LulledLion 9/1/24
+    #Script by LulledLion 9-1-24
     @Condition eventPlayer.isAlive() == true
     @Condition eventPlayer.isOnGround() == false
-    @Condition eventPlayer.DoubleUsed == (eventPlayer.getCurrentHero() == Hero.GENJI)
+    @Condition eventPlayer.getCurrentHero() == Hero.GENJI == eventPlayer.DoubleUsed
+    @Condition eventPlayer.getCurrentHero() == Hero.HANZO == eventPlayer.getAbilityCooldown(Button.JUMP)
+    @Condition (eventPlayer.getCurrentHero() == Hero.KIRIKO and eventPlayer.isHoldingButton(Button.JUMP)) == (eventPlayer.getCurrentHero() == Hero.KIRIKO)
     
     #Directly after Double Jumping
     eventPlayer.stopForcingButton(Button.JUMP)
@@ -369,6 +371,9 @@ rule "Ledge Grab Patch 1.4":
     eventPlayer.stopForcingButton(Button.JUMP)
     #Ledge Grab loop
     while not eventPlayer.isOnGround():
+        #Hero Swap
+        if not RULE_CONDITION:
+            return
         #Multi-Climb
         if eventPlayer.isOnWall():
             wait(false)

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -300,8 +300,9 @@ rule "Grup up | function":
     wait(1, Wait.ABORT_WHEN_FALSE)
 
     eventPlayer.startForcingPosition(CheckpointPositions[eventPlayer.CurrentCheckpoint +1] + vect(0,0.1,0), true)
-    eventPlayer.cancelPrimaryAction()
     eventPlayer.setStatusEffect(null, Status.ROOTED, 0.3)
+    eventPlayer.cancelPrimaryAction()
+    eventPlayer.DoubleUsed = null
     wait(0.16)
     eventPlayer.stopForcingPosition()
 
@@ -340,9 +341,39 @@ rule "Custom Orb Script":
     if eventPlayer.BounceTrueId in [2,3]:
        # example canceling primary makes double jump recover
        eventPlayer.cancelPrimaryAction()
+       eventPlayer.DoubleUsed = null
        smallMessage(eventPlayer," double jump recovered")
                 
     if eventPlayer.BounceTrueId in [4]:
         # example move speed
         eventPlayer.setMoveSpeed(250)
         smallMessage(eventPlayer," zooom")
+
+rule "Ledge Grab Patch 1.3":
+    @Disabled
+    @Event eachPlayer
+    #Script by LulledLion
+    #08/28/24
+    @Condition eventPlayer.isAlive() == true
+    @Condition eventPlayer.isOnGround() == false
+    @Condition eventPlayer.DoubleUsed == (eventPlayer.getCurrentHero() == Hero.GENJI)
+    
+    #Directly after Double Jumping
+    eventPlayer.stopForcingButton(Button.JUMP)
+    wait(false)
+    eventPlayer.startForcingButton(Button.JUMP)
+    wait(false)
+    eventPlayer.stopForcingButton(Button.JUMP)
+    wait(false)
+    eventPlayer.startForcingButton(Button.JUMP)
+    waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+    eventPlayer.stopForcingButton(Button.JUMP)
+    #Ledge Grab Loop
+    while not eventPlayer.isOnGround():
+        #Multi-Climb | Refresh Bhop
+        if not eventPlayer.isOnWall():
+            eventPlayer.startForcingButton(Button.JUMP)
+            wait(false)
+            eventPlayer.stopForcingButton(Button.JUMP)
+        waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -327,7 +327,6 @@ rule "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳":
     if eventPlayer.isHoldingButton(Button.JUMP) and eventPlayer.isJumping():
         eventPlayer.applyImpulse(Vector.UP, 9, Relativity.TO_PLAYER, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
 
-/* Blizzard Fixed | For safe keeping but do not compile
 rule "Ledge Grab Patch v1.5":
     @Disabled
     @Event eachPlayer
@@ -361,4 +360,3 @@ rule "Ledge Grab Patch v1.5":
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
         #Create cBhop
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.CROUCH), 0.064)
-*/

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -118,52 +118,9 @@ rule "Hint text for certain Checkpoints - 特定关卡的提示文本 <---- EDIT
     # 修改数组 “HintCp” 为提示文本 显示的关卡
     HintCp = [1, 3]
 
-
 rule "------------------------------------------------------------------------ Addons skills - 附加组件技能 ------------------------------------------------------------------------":
     @Delimiter
     @Disabled
-
-rule "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳": # method c
-    @Disabled
-    @Event eachPlayer
-    @Hero genji
-    # check starts in air when not double jumping, this is to detect double jumping
-    @Condition eventPlayer.isOnGround() == false 
-    @Condition eventPlayer.isJumping() # false when double jumping
-
-    @Condition eventPlayer.getAltitude() < 0.5 # prevent rest of code from runing if you are not gona be close to ground
-    @Condition eventPlayer.getVerticalSpeed() < 0 # avoid trigering on start of jump, only when u go downwards
-    
-    @Condition eventPlayer.isHoldingButton(Button.RELOAD) == false # don't triger on reset
-    @Condition eventPlayer.isUsingAbility1() == false
-    @Condition eventPlayer.isOnWall() == false
-
-    waitUntil(
-        eventPlayer.isOnGround() or 
-        eventPlayer.isJumping() == false or 
-        eventPlayer.isOnWall() or  
-        eventPlayer.isUsingAbility1() or 
-        eventPlayer.isHoldingButton(Button.RELOAD)
-        , 999
-    ) # if you double jump or climb etc before touching ground, reset
-    
-    if eventPlayer.isOnGround() == false and eventPlayer.isJumping() == false or eventPlayer.isOnWall() or eventPlayer.isUsingAbility1() or eventPlayer.isHoldingButton(Button.RELOAD) : # 
-        return
-    
-    waitUntil(
-        (eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP)) or
-        eventPlayer.isOnWall() or  
-        eventPlayer.isUsingAbility1() or 
-        eventPlayer.isHoldingButton(Button.RELOAD),
-        0.048
-    ) # window on the ground were you can press jump
-
-    if eventPlayer.isOnWall() or eventPlayer.isUsingAbility1() or eventPlayer.isHoldingButton(Button.RELOAD) or eventPlayer.hasStatusEffect(Status.ROOTED):
-        return
-
-    if eventPlayer.isHoldingButton(Button.JUMP) and eventPlayer.isJumping() :
-        # ban goes here if it was on
-        eventPlayer.applyImpulse(Vector.UP, 9, Relativity.TO_PLAYER, Impulse.CANCEL_CONTRARY_MOTION)
 
 # keeps you still shortly after getting in a stall
 # makes it much easier to get in one
@@ -206,7 +163,6 @@ rule "Stall enhancer - 增强系統跳的判定 - 启用此规则":
         if RULE_CONDITION:
             goto RULE_START
 
-
 # dash after ledge grab
 # stores speed and launches you after dash if you done it during climb
 # LedgeDash var 0 count - 1 eventPlayer.LedgeDash[1] 1 stored speed
@@ -241,8 +197,6 @@ rule "Fake Ledge Dash - enable rule - 超级跳 - 启用此规则":
     eventPlayer.LedgeDash[0] = null
     eventPlayer.LedgeDash[1] = null
     eventPlayer.LedgeDash[2] = null
-
-
 
 rule "Grup up | text/effect -":
     @Disabled
@@ -306,8 +260,6 @@ rule "Grup up | function":
     wait(0.16)
     eventPlayer.stopForcingPosition()
 
-
-
 def TriggerOnFailSuccesReset():
     @Name "Custom script on fail, succes, reset, skip"
     @Disabled
@@ -348,6 +300,32 @@ rule "Custom Orb Script":
         # example move speed
         eventPlayer.setMoveSpeed(250)
         smallMessage(eventPlayer," zooom")
+
+rule "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳":
+    @Disabled
+    @Event eachPlayer
+    @Hero genji
+    #Method D
+    #Updated Script by LulledLion 9-1-24
+    @Condition BanTriple == false
+    @Condition eventPlayer.isOnGround() == false
+    @Condition eventPlayer.DoubleUsed == false
+    @Condition eventPlayer.isHoldingButton(Button.RELOAD) == false #Don't trigger on reset
+
+    #Double cannot be used already
+    wait(false)
+    if RULE_CONDITION:
+        goto RULE_START
+    if eventPlayer.DoubleUsed:
+        return
+    #Input window to Triple
+    waitUntil(eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isOnWall() or eventPlayer.isUsingAbility1() or eventPlayer.isHoldingButton(Button.RELOAD), 0.048)
+    #Cancel Triple
+    if eventPlayer.isOnWall() or eventPlayer.isUsingAbility1() or eventPlayer.isHoldingButton(Button.RELOAD) or eventPlayer.hasStatusEffect(Status.ROOTED):
+        return
+    #Apply fake triple jump
+    if eventPlayer.isHoldingButton(Button.JUMP) and eventPlayer.isJumping():
+        eventPlayer.applyImpulse(Vector.UP, 9, Relativity.TO_PLAYER, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
 
 rule "Ledge Grab Patch 1.5":
     @Disabled

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -376,6 +376,4 @@ rule "Ledge Grab Patch 1.3":
             eventPlayer.stopForcingButton(Button.JUMP)
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
-        #Create Bhop fixed? TODO Narrow Timing
-        #Helpful Debuggers Dark Moisty LostJe Amwaj Iloveto M4rtian
-        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.CROUCH), 0.096)
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.CROUCH), 0.064)

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -349,10 +349,10 @@ rule "Custom Orb Script":
         eventPlayer.setMoveSpeed(250)
         smallMessage(eventPlayer," zooom")
 
-rule "Ledge Grab Patch 1.3":
+rule "Ledge Grab Patch 1.4":
     @Disabled
     @Event eachPlayer
-    #Script by LulledLion 08/28/24
+    #Script by LulledLion 9/1/24
     @Condition eventPlayer.isAlive() == true
     @Condition eventPlayer.isOnGround() == false
     @Condition eventPlayer.DoubleUsed == (eventPlayer.getCurrentHero() == Hero.GENJI)
@@ -369,11 +369,15 @@ rule "Ledge Grab Patch 1.3":
     eventPlayer.stopForcingButton(Button.JUMP)
     #Ledge Grab loop
     while not eventPlayer.isOnGround():
-        #Multi-Climb | Create Bhop
+        #Multi-Climb
         if not eventPlayer.isOnWall():
             eventPlayer.startForcingButton(Button.JUMP)
             wait(false)
             eventPlayer.stopForcingButton(Button.JUMP)
-        waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
-        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        else:
+            #Quick Regrab
+            wait(false)
+        waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        #Create cBhop
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.CROUCH), 0.064)

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -370,13 +370,12 @@ rule "Ledge Grab Patch 1.4":
     #Ledge Grab loop
     while not eventPlayer.isOnGround():
         #Multi-Climb
-        if not eventPlayer.isOnWall():
+        if eventPlayer.isOnWall():
+            wait(false)
+        else:
             eventPlayer.startForcingButton(Button.JUMP)
             wait(false)
             eventPlayer.stopForcingButton(Button.JUMP)
-        else:
-            #Quick Regrab
-            wait(false)
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
         #Create cBhop

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -327,10 +327,11 @@ rule "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳":
     if eventPlayer.isHoldingButton(Button.JUMP) and eventPlayer.isJumping():
         eventPlayer.applyImpulse(Vector.UP, 9, Relativity.TO_PLAYER, Impulse.CANCEL_CONTRARY_MOTION_XYZ)
 
-rule "Ledge Grab Patch 1.5":
+/* Blizzard Fixed | For safe keeping but do not compile
+rule "Ledge Grab Patch v1.5":
     @Disabled
     @Event eachPlayer
-    #Script by LulledLion 9-1-24
+    #For OW v2.12
     @Condition eventPlayer.isAlive() == true
     @Condition eventPlayer.isOnGround() == false
     @Condition eventPlayer.getCurrentHero() == Hero.GENJI == eventPlayer.DoubleUsed
@@ -360,3 +361,4 @@ rule "Ledge Grab Patch 1.5":
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isOnWall() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
         #Create cBhop
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.CROUCH), 0.064)
+*/

--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -371,9 +371,6 @@ rule "Ledge Grab Patch 1.5":
     eventPlayer.stopForcingButton(Button.JUMP)
     #Ledge Grab loop
     while not eventPlayer.isOnGround():
-        #Hero Swap
-        if not RULE_CONDITION:
-            return
         #Multi-Climb
         if eventPlayer.isOnWall():
             wait(false)

--- a/commands.opy
+++ b/commands.opy
@@ -57,13 +57,13 @@ rule "Preview orbs/portals | Hold Primary":
     wait(0.45, Wait.ABORT_WHEN_FALSE)
     eventPlayer.PreviewsArray = [CheckpointPositions[eventPlayer.CurrentCheckpoint + 1]]
     
-    if len(BouncePadCheckpoints) > 0:
+    if len(BouncePadCheckpoints):
         eventPlayer.PreviewsArray.append( ( [i for i in BouncePositions if BouncePadCheckpoints[BouncePositions.index(i)] == eventPlayer.CurrentCheckpoint] ) )
         eventPlayer.PreviewsArray2 = [-2] # first entry is checkpoint itself, -1 would overlap with -1 in some orbs
         eventPlayer.PreviewsArray2.append( [i for _, i in BouncePadCheckpoints] )
         eventPlayer.PreviewsArray2 = [ i for i in eventPlayer.PreviewsArray2 if BouncePadCheckpoints[i] == eventPlayer.CurrentCheckpoint or i == -2 ] 
 
-    if len(CustomPortalStart) > 0:
+    if len(CustomPortalStart):
         #eventPlayer.PreviewsArray.append( [i for i in CustomPortalStart if CustomPortalCP[CustomPortalStart.index(i)] == eventPlayer.CurrentCheckpoint] )
         for eventPlayer.PreviewsI in range(len(eventPlayer.PortalStart_Cache)):
             eventPlayer.PreviewsArray.append([eventPlayer.PortalStart_Cache[eventPlayer.PreviewsI ],eventPlayer.PortalEnd_cache[eventPlayer.PreviewsI ]])
@@ -454,8 +454,6 @@ rule "Quick Reset | Reload, Hold Reload to Enable":
         "Quick reset is enabled" if eventPlayer.QuickRestartToggle else "Quick reset is disabled"
     )
 
-
-
 rule "Toggle Hud | hold secondary":
     @Event eachPlayer
     @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
@@ -474,7 +472,6 @@ rule "Toggle Hud | hold secondary":
     ) 
     
     eventPlayer.GuideToggle = not eventPlayer.GuideToggle 
-
 
 rule "Toggle hints":
     @Event eachPlayer

--- a/definitions.opy
+++ b/definitions.opy
@@ -7,7 +7,6 @@
 ##!define prettyTime(timeInSeconds) "{0} {1}".format(timeInSeconds,"秒"  checkCN "sec")
 #!define prettyTime(timeInSeconds) "{0} sec".format(timeInSeconds)
 
-
 #!define insert(insert_array, insert_index, insert_value)  insert_array.append(insert_value) \
         insert_array = [elementhere if i < insert_index else insert_array.last() if i == insert_index else insert_array[i - 1] for elementhere, i in insert_array]
 
@@ -19,7 +18,6 @@ else:\
 
 #!define RemoveCPandLower(arrayname)  arrayname = [i for i in arrayname if i != hostPlayer.CurrentCheckpoint ]\
 arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayname]
-
 
 # check if cn client
 /*
@@ -34,7 +32,6 @@ arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayn
 #!define checkCN if l"Capture" == "捕捉" or l"Capture" == "捕捉" or "{0}".format(Color.ROSE) == "玫红" else
 # debug turn on cn
 ##!define checkCN if true  else
-
 
 ##!define FILLER rule "Addon settings are on next page! Click the next page button!":\
 ##!define FILLER rule "Map data and addon settings are on page 2 !!!!!!!!!!!!!!!!!!!":\
@@ -83,7 +80,6 @@ arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayn
 #37
 #!define TempIterator1 NANBA
 
-
 # ----------------PLAYER------------------
 #!define CurrentCheckpoint A
 ##!define PlayerEffects B
@@ -121,47 +117,42 @@ arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayn
            
 #!define BhopHUDColor CH           
 
-
 # ----------------SUBS------------------
 #!define StartGame_Sub Sub1
 ##!define KILLBALL KILLBALL
 ##!define pinball pinball
 
-
-
-
-
 #Global variables
 globalvar CheckpointPositions 0             # list[vect | list[vect]]   --- sometimes nested - 0 original end, 1 teleported
-#globalvar SelectedCheckpoint_Editing 1 # legacy      # int                       --- selected checkpoint
+#globalvar SelectedCheckpoint_Editing 1     # legacy      # int         --- selected checkpoint
 globalvar CheckpointRings_Editing 2         # list[effect]              --- Holds checkpoint effects in editing context
 globalvar MsDestructo 3                     # MsDestructo Player
 globalvar TimeRemaining 4
 globalvar PortalEffects 5                   # list[effect]              --- Array holding custom portal effects
 #globalvar CurrentPortalEditing 6
-#globalvar Portal1PlayerList 5               # list[player]              --- players who can see portal 1
-#globalvar Portal2PlayerList 6               # list[player]              --- players who can see portal 2
+#globalvar Portal1PlayerList 5              # list[player]              --- players who can see portal 1
+#globalvar Portal2PlayerList 6              # list[player]              --- players who can see portal 2
 globalvar KillBallPositions 7               # list[vect]                --- KillBall position
 globalvar KillBallRadii 8                   # list[float]               --- KillBall radius, default 5
-#globalvar SelectedKillball_Editing 9        # int                       --- Current killball in editing context
+#globalvar SelectedKillball_Editing 9       # int                       --- Current killball in editing context
 globalvar KillBallEffects 10                # list[effect]              --- Array holding killball effects
-#globalvar KillBallChase 11                  # vect                      --- Location of killball while editing, chased.
+#globalvar KillBallChase 11                 # vect                      --- Location of killball while editing, chased.
 globalvar BladeEnabledCheckpoints 12        # int                       --- blade enabled, should be bool.
 globalvar DashEnabledCheckpoints 13         # int                       --- dash enabled, should be bool.
-#globalvar ListPlayersAtCheckpoints 15       # list[list[player]]        --- players at a specific checkpoint
-#globalvar ActivePlayers 16                  # list[player]              --- Active players, Non-saved, non-spectating active players
-#globalvar EditorOn 17                       # bool                      --- editor rules enabled?
+#globalvar ListPlayersAtCheckpoints 15      # list[list[player]]        --- players at a specific checkpoint
+#globalvar ActivePlayers 16                 # list[player]              --- Active players, Non-saved, non-spectating active players
+#globalvar EditorOn 17                      # bool                      --- editor rules enabled?
 globalvar EditSelected 14
 globalvar EditSelectIdArray 15
 
-#globalvar EditorMoveItem 16                          # num                       --- used for moving a portal
+#globalvar EditorMoveItem 16                # num                       --- used for moving a portal
 
 #Bounce Pad editing stuff
 globalvar BouncePositions 18                # list[vect]                --- list of bouncepad positions
-#globalvar CurrentBounce_Editing 19          # int                       --- count of 0-indexed bouncepad pos currently
+#globalvar CurrentBounce_Editing 19         # int                       --- count of 0-indexed bouncepad pos currently
 globalvar BounceEffects 20                  # list[effects]             --- list of bounce pad effect entities
-#globalvar CurrentBouncePosition_Editing 21  # vect                      --- the position we just added to bouncepad positions
-globalvar EditorMoveItem 21                          # num                       --- used for moving a portal
+#globalvar CurrentBouncePosition_Editing 21 # vect                      --- the position we just added to bouncepad positions
+globalvar EditorMoveItem 21                 # num                       --- used for moving a portal
 
 globalvar BounceStrength 22                 # list[float]               --- bouncepad strength
 globalvar BounceToggleUlt 23                # list[bool]                --- toggle ult on bounce
@@ -183,11 +174,9 @@ globalvar LeaderBoardHuds 33
 globalvar LeaderBoardRemake 34              # bool                      --- indicate board needs remaking
 globalvar BhopBanToggle 35                  # bool                      --- Enabled if Bhop is banned
 
-
 globalvar TempIterator1 38                  # int                       --- temp iterator
 
 globalvar DashExploitToggle 39
-
 
 globalvar PortalNames 40                    # [str]                     --- display name of portals
 globalvar PortalLoc 41                      # [vect]                    --- portal position
@@ -203,7 +192,7 @@ globalvar CompMode 50                       # bool                      --- comp
 globalvar CompTime 51                       # int                       --- compt mode time limit
 globalvar CompAtmpNum 52                    # int                       --- compt mode attempt limit
 globalvar CompAtmpSaveNames 53              # [strings]                 --- comp name list
-globalvar CompAtmpSaveCount 54              # [int]                      --- compt attempt list
+globalvar CompAtmpSaveCount 54              # [int]                     --- compt attempt list
 globalvar CompRestartLimit 55               # bool                      --- resest limiter
 globalvar instructiontext 56                # [text]                    --- array of instructions
 globalvar TitleData 57                      # [[cp ,[title],[color]]    --- title addon 
@@ -255,19 +244,19 @@ playervar CurrentCheckpoint 0               # int                       --- Curr
 #2 - Next lightshaft, 
 #3 - Next arrow icon, 
 #4 - Next "Come here" text
-#playervar PlayerEffects 1                   # list[effect]              --- Player effect data array  
-playervar InvincibleToggle 2                # bool                       --- invincible/normal mode toggle now a bool
+#playervar PlayerEffects 1                  # list[effect]              --- Player effect data array  
+playervar InvincibleToggle 2                # bool                      --- invincible/normal mode toggle now a bool
 playervar Timer 3                           # float                     --- Timer, chased.
 playervar EditModeSelection 4               # int                       --- EditMode - 1 checkpoint | 2 Killing sphere | 3 Bouncing ball
-playervar SpectateToggle 5                  # bool                       --- turned into bool
-#playervar ArrayIterator 6                   # MsDestructo Iterator
-#playervar PortalText 7                      # In-World Text             --- Portal String inworld text
-#playervar MapVectorArray 8                  # MsDestructo Vectors
+playervar SpectateToggle 5                  # bool                      --- turned into bool
+#playervar ArrayIterator 6                  # MsDestructo Iterator
+#playervar PortalText 7                     # In-World Text             --- Portal String inworld text
+#playervar MapVectorArray 8                 # MsDestructo Vectors
 playervar LedgeDash 6
 playervar LockEditor 7                      # bool                      --- ensure only 1 editor command can go of at the time
 playervar DontPlay
 playervar WallclimbUsed 9                   # bool                      --- turned into bool
-playervar GuideToggle 10                    # bool                       --- turned into bool, shows/hides editor hud
+playervar GuideToggle 10                    # bool                      --- turned into bool, shows/hides editor hud
 playervar LockState 11                      # bool                      --- locked means you are curently runing arrive checkpoint rule
 playervar PauseTimer 12                     # float                     --- time in spectate/invincible, chased
 playervar Temp 13                           
@@ -281,9 +270,9 @@ playervar Bhopcount                         # int                       --- coun
 playervar JumpCount 26                      # int                       --- jump tracking count, 0, 1, 2
 playervar MultiClimbCountHUD 28             # HUD                       --- climb counter
 playervar CreateCounter 29
-playervar QuickRestartToggle 31             # bool                      -- enable reload to restart cp
+playervar QuickRestartToggle 31             # bool                      --- enable reload to restart cp
 playervar MultiClimbCount 32                # int                       --- climb count # for HUD
-playervar finishfxcache  33                   # color                     --- color of fx after finish the map
+playervar finishfxcache  33                 # color                     --- color of fx after finish the map
 playervar HintsOn 34
 playervar PreviewsArray2 37
 playervar PreviewsArray 38                  # array                     --- store preview positions
@@ -291,11 +280,11 @@ playervar PreviewsI 39                      # int                       --- prev
 playervar invis 40                          # bool                      --- invis toggle added by fisho
 playervar flytoggle 41                      # vector/null               --- null if not flying, else vector position, added by fisho
 playervar savemaphud 42                     # array                     --- array of save map hud ids
-#playervar TracesOff 43                      # bool                      --- turn traces (ring explosion fx) off
+#playervar TracesOff 43                     # bool                      --- turn traces (ring explosion fx) off
 playervar EditorOn 45                       # bool                      --- on all players, but only gets checked from host player
 playervar LockCollected 46                  # number                    --- amount collected lock this cp
 playervar bouncetouched 47                  # int                       --- cache of the bouncepad id you are currently touching
-#playervar PortalLoop 48                     # int                       --- loop to select portal
+#playervar PortalLoop 48                    # int                       --- loop to select portal
 playervar PortalStart_Cache 48
 playervar BounceLockMax_Cache 49
 playervar KillPosition_Cache 50

--- a/definitions.opy
+++ b/definitions.opy
@@ -334,7 +334,7 @@ playervar splitdisplay 80                   # int                       --- disp
 playervar practicetimer 82
 playervar ult_cd_global                     # int                       --- tracks cd for ult even if rule restarts the waits
 playervar BhopHUDColor 85                   # Color                     --- Color for Bhop HUD
-
+playervar DoubleUsed 86                     # bool
 
 #Subroutine names
 subroutine StartGame_Sub 1

--- a/editor.opy
+++ b/editor.opy
@@ -164,7 +164,7 @@ def RebuildKillOrbs(): # triggers in editor. delets the current orbs to place on
 def RebuildPortals():
     destroyEffect(PortalEffects)
     PortalEffects = [] 
-    if len(CustomPortalCP) < 1:
+    if CustomPortalCP == []:
         return
     
     for TempIterator1 in range(0, len(CustomPortalCP)):
@@ -202,9 +202,9 @@ rule "Editor | Hud and Effects":
         getAllPlayers().AttemptCount = null
         getAllPlayers().CompDone = false
 
-    #CustomPortalStart = CustomPortalStart if len(CustomPortalStart) > 0 else [] 
+    #CustomPortalStart = CustomPortalStart if len(CustomPortalStart) else [] 
     #CustomPortalEndpoint = CustomPortalEndpoint if len(CustomPortalEndpoint) > 0 else [] 
-    #CustomPortalCP = CustomPortalCP if len(CustomPortalCP) > 0 else [] 
+    #CustomPortalCP = CustomPortalCP if len(CustomPortalCP) else [] 
 
     # huds ==========================================================================================================================================================================
     
@@ -519,7 +519,7 @@ rule "Editor | Hud and Effects":
         "{3} 封禁(单关) \n" 
         "{4} 自定义传送门 "
         "".format(
-        iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 0 else "     ",
+        iconString(Icon.ARROW_RIGHT) if not hostPlayer.EditModeSelection else "     ",
         iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 1 else "     ",
         iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 2 else "     ",
         iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 3 else "     ",
@@ -539,7 +539,7 @@ rule "Editor | Hud and Effects":
         "{3} checkpoint bans\n"
         "{4} portals "
         "".format(
-        iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 0 else "     ",
+        iconString(Icon.ARROW_RIGHT) if not hostPlayer.EditModeSelection else "     ",
         iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 1 else "     ",
         iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 2 else "     ",
         iconString(Icon.ARROW_RIGHT) if hostPlayer.EditModeSelection == 3 else "     ",
@@ -576,14 +576,14 @@ rule "Editor | Hud and Effects":
             HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
     )
 
-    hudSubtext(hostPlayer if hostPlayer.GuideToggle and (hostPlayer.EditModeSelection == 0 or hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache) > 0) else null, #if hostPlayer.EditModeSelection == 0 or hostPlayer.EditModeSelection == 2 and hostPlayer.GuideToggle and len(hostPlayer.BounceIndex_Cache) > 0 else null, 
+    hudSubtext(hostPlayer if hostPlayer.GuideToggle and (not hostPlayer.EditModeSelection or hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache)) else null, #if not hostPlayer.EditModeSelection or hostPlayer.EditModeSelection == 2 and hostPlayer.GuideToggle and len(hostPlayer.BounceIndex_Cache) else null, 
         "{0} + {1} | {4} {3} | {2}".format(              
             buttonString(Button.ULTIMATE), 
             buttonString(Button.PRIMARY_FIRE), 
             ("启用" if BounceToggleUlt[EditSelected] != 0 else "关闭") if  hostPlayer.EditModeSelection == 2 else
             ("启用" if hostPlayer.CurrentCheckpoint in BladeEnabledCheckpoints else "关闭"),
             abilityIconString(Hero.GENJI, Button.ULTIMATE),
-            "检查点给刀"  if hostPlayer.EditModeSelection == 0 else "弹球给刀"
+            "检查点给刀"  if not hostPlayer.EditModeSelection else "弹球给刀"
         )        
         checkCN
         "{0} + {1} | {4} give ult {3} | {2}".format(
@@ -592,23 +592,23 @@ rule "Editor | Hud and Effects":
             ("on" if BounceToggleUlt[EditSelected] != 0 else "off") if  hostPlayer.EditModeSelection == 2 else
             ("on" if hostPlayer.CurrentCheckpoint in BladeEnabledCheckpoints else "off"),
             abilityIconString(Hero.GENJI, Button.ULTIMATE),
-            "Level" if hostPlayer.EditModeSelection == 0  else "Orb"
+            "Level" if not hostPlayer.EditModeSelection  else "Orb"
         )        
         , HudPosition.LEFT, HO.edit_orb_ult, 
         Color.GREEN if BounceToggleUlt[EditSelected] != 0 and hostPlayer.EditModeSelection == 2 else
-        Color.GREEN if hostPlayer.CurrentCheckpoint in BladeEnabledCheckpoints and hostPlayer.EditModeSelection == 0 else
+        Color.GREEN if hostPlayer.CurrentCheckpoint in BladeEnabledCheckpoints and not hostPlayer.EditModeSelection else
         Color.ORANGE
         , HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
     )
 
-    hudSubtext(hostPlayer if hostPlayer.GuideToggle and (hostPlayer.EditModeSelection == 0 or hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache) > 0) else null, #if hostPlayer.EditModeSelection == 0 or hostPlayer.EditModeSelection == 2 and hostPlayer.GuideToggle and len(hostPlayer.BounceIndex_Cache) > 0 else null, 
+    hudSubtext(hostPlayer if hostPlayer.GuideToggle and (not hostPlayer.EditModeSelection or hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache)) else null, #if not hostPlayer.EditModeSelection or hostPlayer.EditModeSelection == 2 and hostPlayer.GuideToggle and len(hostPlayer.BounceIndex_Cache) else null, 
         "{0} + {1} | {4} {3} | {2}".format(
             buttonString(Button.ULTIMATE), 
             buttonString(Button.SECONDARY_FIRE), 
             ("启用" if BounceToggleDash[EditSelected] != 0 else "关闭") if  hostPlayer.EditModeSelection == 2 else
             ("启用" if hostPlayer.CurrentCheckpoint in DashEnabledCheckpoints else "关闭"),
             abilityIconString(Hero.GENJI, Button.ABILITY_1),
-           "检查点给Shift" if hostPlayer.EditModeSelection == 0 else "弹球给Shift"
+           "检查点给Shift" if not hostPlayer.EditModeSelection else "弹球给Shift"
         )   
         checkCN
         "{0} + {1} | {4} give dash {3} | {2}".format(
@@ -617,17 +617,17 @@ rule "Editor | Hud and Effects":
             ("on" if BounceToggleDash[EditSelected] != 0 else "off") if  hostPlayer.EditModeSelection == 2 else
             ("on" if hostPlayer.CurrentCheckpoint in DashEnabledCheckpoints else "off"),
             abilityIconString(Hero.GENJI, Button.ABILITY_1),
-            "Level" if hostPlayer.EditModeSelection == 0
+            "Level" if not hostPlayer.EditModeSelection
             else "Orb"
         )        
         , HudPosition.LEFT, HO.edit_orb_dash, 
         Color.GREEN if BounceToggleDash[EditSelected] != 0 and hostPlayer.EditModeSelection == 2 else
-        Color.GREEN if hostPlayer.CurrentCheckpoint in DashEnabledCheckpoints and hostPlayer.EditModeSelection == 0 else
+        Color.GREEN if hostPlayer.CurrentCheckpoint in DashEnabledCheckpoints and not hostPlayer.EditModeSelection else
         Color.ORANGE
         , HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
     )
 
-    hudSubtext(hostPlayer if hostPlayer.EditModeSelection == 2 and hostPlayer.GuideToggle and len(hostPlayer.BounceIndex_Cache) > 0 else null,
+    hudSubtext(hostPlayer if hostPlayer.EditModeSelection == 2 and hostPlayer.GuideToggle and len(hostPlayer.BounceIndex_Cache) else null,
         "{0} + {1} |  收集球(进点前必须集齐) {3} | {2}\n".format(
             buttonString(Button.ULTIMATE), 
             buttonString(Button.ABILITY_2),
@@ -659,18 +659,18 @@ rule "Editor | Hud and Effects":
                 "" if len(CheckpointPositions[hostPlayer.CurrentCheckpoint]) < 2 else
                 "\n 传送点: {0}".format(CheckpointPositions[hostPlayer.CurrentCheckpoint][1])
             ) 
-            if hostPlayer.EditModeSelection == 0 and len(CheckpointPositions) > 0 else  
+            if not hostPlayer.EditModeSelection and len(CheckpointPositions) else  
             "\n 选中的击杀球 \n 矢量: {1} \n 半径: {0} \n".format(
                 KillBallRadii[EditSelected],
                 KillBallPositions[EditSelected]      
             ) 
-            if hostPlayer.EditModeSelection == 1 and len(hostPlayer.KillIndex_Cache) > 0 else             
+            if hostPlayer.EditModeSelection == 1 and len(hostPlayer.KillIndex_Cache) else             
             "\n 选中的弹球 \n 矢量: {1} \n 弹力: {0} \n 序号: {2} \n".format(
                 BounceStrength[EditSelected],
                 BouncePositions[EditSelected],
                 EditSelected
             )
-            if hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache) > 0  else  
+            if hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache)  else  
             "\n 封禁(单关)\n"
             "――――――――――――\n"
             " {} 蹭留\n"
@@ -709,18 +709,18 @@ rule "Editor | Hud and Effects":
                 "" if len(CheckpointPositions[hostPlayer.CurrentCheckpoint]) < 2 else
                 "\n Teleport: {0}".format(CheckpointPositions[hostPlayer.CurrentCheckpoint][1])
             ) 
-            if hostPlayer.EditModeSelection == 0 and len(CheckpointPositions) > 0 else  
+            if not hostPlayer.EditModeSelection and len(CheckpointPositions) else  
             "\n Selected Kill Orb \n Vector: {1} \n radius: {0} \n".format(
                 KillBallRadii[EditSelected],
                 KillBallPositions[EditSelected]      
             ) 
-            if hostPlayer.EditModeSelection == 1 and len(hostPlayer.KillIndex_Cache) > 0 else             
+            if hostPlayer.EditModeSelection == 1 and len(hostPlayer.KillIndex_Cache) else             
             "\n Selected Bounce Orb \n Vector: {1} \n strength: {0} \n ID: {2} \n".format(
                 BounceStrength[EditSelected],
                 BouncePositions[EditSelected],
                 EditSelected
             )
-            if hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache) > 0  else   
+            if hostPlayer.EditModeSelection == 2 and len(hostPlayer.BounceIndex_Cache)  else   
             "\n bans\n"
             "――――――――――――\n"
             " {} multi\n"
@@ -749,7 +749,7 @@ rule "Editor | Hud and Effects":
                 CustomPortalEndpoint[EditSelected],
                 "All" if CustomPortalCP[EditSelected] == 999 else hostPlayer.CurrentCheckpoint
                 )
-            if hostPlayer.EditModeSelection == 4 and CustomPortalCP[EditSelected] in [hostPlayer.CurrentCheckpoint,999] and len(CustomPortalCP) > 0 else
+            if hostPlayer.EditModeSelection == 4 and CustomPortalCP[EditSelected] in [hostPlayer.CurrentCheckpoint,999] and len(CustomPortalCP) else
 
             "\n   No data selected   \n"
             
@@ -761,7 +761,7 @@ rule "Editor | Hud and Effects":
     wait(1)
     # effects ==========================================================================================================================================================================   
     createInWorldText(
-        getAllPlayers() if len(EditSelectIdArray) > 0 else null,     
+        getAllPlayers() if len(EditSelectIdArray) else null,     
         "选中的实体" checkCN "selected"
         , 
         KillBallPositions[EditSelected] if hostPlayer.EditModeSelection == 1 else
@@ -772,7 +772,7 @@ rule "Editor | Hud and Effects":
     )
 
     createIcon(
-        getAllPlayers() if len(EditSelectIdArray) > 0 else null,     
+        getAllPlayers() if len(EditSelectIdArray) else null,     
         KillBallPositions[EditSelected] if hostPlayer.EditModeSelection == 1 else
         BouncePositions[EditSelected] if hostPlayer.EditModeSelection == 2 else
         CustomPortalStart[EditSelected] if hostPlayer.EditModeSelection == 4 else
@@ -782,17 +782,17 @@ rule "Editor | Hud and Effects":
     )
 
     # Purple sphere for teleport location
-    createEffect(getAllPlayers() if len(CheckpointPositions[hostPlayer.CurrentCheckpoint] ) > 1 and hostPlayer.EditModeSelection == 0 else null, Effect.SPHERE, Color.PURPLE, CheckpointPositions[hostPlayer.CurrentCheckpoint][1]-vect(0,0.1,0), 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    createEffect(getAllPlayers() if len(CheckpointPositions[hostPlayer.CurrentCheckpoint] ) > 1 and not hostPlayer.EditModeSelection else null, Effect.SPHERE, Color.PURPLE, CheckpointPositions[hostPlayer.CurrentCheckpoint][1]-vect(0,0.1,0), 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
   
     # Teleport text
-    createInWorldText(getAllPlayers() if len(CheckpointPositions[hostPlayer.CurrentCheckpoint] ) > 1 and hostPlayer.EditModeSelection == 0 else null, "传送点位置" checkCN "teleporter location", CheckpointPositions[hostPlayer.CurrentCheckpoint][1], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
+    createInWorldText(getAllPlayers() if len(CheckpointPositions[hostPlayer.CurrentCheckpoint] ) > 1 and not hostPlayer.EditModeSelection else null, "传送点位置" checkCN "teleporter location", CheckpointPositions[hostPlayer.CurrentCheckpoint][1], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
         
     # normal cp if teleport
-    createEffect(hostPlayer if CheckpointPositions[hostPlayer.CurrentCheckpoint][1] and hostPlayer.EditModeSelection == 0 else null, Effect.RING, Color.ORANGE, CheckpointPositions[hostPlayer.CurrentCheckpoint][0], 1, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
-    createInWorldText(hostPlayer if CheckpointPositions[hostPlayer.CurrentCheckpoint][1] and hostPlayer.EditModeSelection == 0 else null, "检查点位置" checkCN "level location", CheckpointPositions[hostPlayer.CurrentCheckpoint][0], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
+    createEffect(hostPlayer if CheckpointPositions[hostPlayer.CurrentCheckpoint][1] and not hostPlayer.EditModeSelection else null, Effect.RING, Color.ORANGE, CheckpointPositions[hostPlayer.CurrentCheckpoint][0], 1, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    createInWorldText(hostPlayer if CheckpointPositions[hostPlayer.CurrentCheckpoint][1] and not hostPlayer.EditModeSelection else null, "检查点位置" checkCN "level location", CheckpointPositions[hostPlayer.CurrentCheckpoint][0], 1.6, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, Color.SKY_BLUE, SpecVisibility.DEFAULT)
     
     # portal fx
-    createEffect(hostPlayer if len(EditSelectIdArray) > 0 and hostPlayer.EditModeSelection == 4 else null, Effect.SPARKLES, Color.PURPLE, CustomPortalEndpoint[EditSelected], 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
+    createEffect(hostPlayer if len(EditSelectIdArray) and hostPlayer.EditModeSelection == 4 else null, Effect.SPARKLES, Color.PURPLE, CustomPortalEndpoint[EditSelected], 0.2, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
 
 # global functions ==============================================================
 rule "Editor |  Fly/Noclip Toggle":
@@ -914,7 +914,7 @@ rule "Editor | create cp/orb":
 
         smallMessage(getAllPlayers(), "   新检查点已创建" checkCN "   New Checkpoint has been created")
     
-    elif len(CheckpointPositions) < 1:
+    elif CheckpointPositions == []:
         smallMessage(eventPlayer, "   请先放置检查点" checkCN "   You first have to make a checkpoint")
         goto endlbl
     elif len(BouncePositions) + len(KillBallPositions) + len(CustomPortalStart) >= fxlimit:
@@ -1000,11 +1000,11 @@ rule "Editor | delete cp/orb/portal":
     @Condition eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
     @Condition eventPlayer == hostPlayer
     #@Condition EditorMoveItem == false
-    #@Condition len(EditSelectIdArray) > 0
+    #@Condition EditSelectIdArray != []
     @Condition eventPlayer.LockEditor == false
 
     eventPlayer.LockEditor = true
-    if eventPlayer.EditModeSelection == 0 and len(CheckpointPositions) > 0:
+    if not eventPlayer.EditModeSelection and len(CheckpointPositions):
         # Resync Kill Orbs ==================
         eventPlayer.Temp = []
         eventPlayer.Temp = [e for e in [(i if e2 == hostPlayer.CurrentCheckpoint else -1) for e2, i in KillballCheckpoints] if  e >=0]
@@ -1069,7 +1069,7 @@ rule "Editor | delete cp/orb/portal":
         del CheckpointPositions[hostPlayer.CurrentCheckpoint]
         del CheckpointRings_Editing[hostPlayer.CurrentCheckpoint]
         
-        if hostPlayer.CurrentCheckpoint < 1 and len(CheckpointPositions) > 0 or CheckpointPositions == []:
+        if hostPlayer.CurrentCheckpoint < 1 and len(CheckpointPositions) or CheckpointPositions == []:
             hostPlayer.CurrentCheckpoint = 0
             goto lbl_a
 
@@ -1079,14 +1079,14 @@ rule "Editor | delete cp/orb/portal":
         RebuildBounceOrbs()
         RebuildPortals()
         smallMessage(getAllPlayers(), "   检查点已删除" checkCN "   Checkpoint has been deleted")
-    elif eventPlayer.EditModeSelection == 1 and len(EditSelectIdArray) > 0:
+    elif eventPlayer.EditModeSelection == 1 and len(EditSelectIdArray):
         del KillBallPositions[EditSelected]
         del KillBallRadii[EditSelected]
         del KillballCheckpoints[EditSelected]
         destroyEffect(KillBallEffects[EditSelected])
         del KillBallEffects[EditSelected]
         RebuildKillOrbs()
-    elif eventPlayer.EditModeSelection == 2 and len(EditSelectIdArray) > 0:
+    elif eventPlayer.EditModeSelection == 2 and len(EditSelectIdArray):
         del BouncePositions[EditSelected]
         del BounceStrength[EditSelected]
         del BounceToggleUlt[EditSelected]
@@ -1096,7 +1096,7 @@ rule "Editor | delete cp/orb/portal":
         del BounceEffects[EditSelected]
         del BouncePadCheckpoints[EditSelected]
         RebuildBounceOrbs()
-    elif eventPlayer.EditModeSelection == 4 and len(EditSelectIdArray) > 0: 
+    elif eventPlayer.EditModeSelection == 4 and len(EditSelectIdArray): 
         destroyEffect(PortalEffects[EditSelected])
         wait()
         del CustomPortalStart[EditSelected]
@@ -1123,7 +1123,7 @@ rule "Editor | toggle orb functions":
     @Condition eventPlayer.EditModeSelection == 2
     @Condition eventPlayer.isHoldingButton(Button.ULTIMATE)
     @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE) or eventPlayer.isHoldingButton(Button.ABILITY_2) 
-    @Condition len(EditSelectIdArray) > 0
+    @Condition EditSelectIdArray != []
     @Condition eventPlayer.LockEditor == false
 
     eventPlayer.LockEditor = true
@@ -1144,7 +1144,7 @@ rule "Editor | orb radi/strength":
     @Condition hostPlayer.EditorOn
     @Condition eventPlayer == hostPlayer 
     @Condition eventPlayer.EditModeSelection in [1,2]
-    @Condition len(EditSelectIdArray) > 0
+    @Condition EditSelectIdArray != []
     @Condition eventPlayer.isHoldingButton(Button.ABILITY_2) 
     @Condition eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isHoldingButton(Button.CROUCH) 
     @Condition eventPlayer.isHoldingButton(Button.INTERACT) == false
@@ -1152,9 +1152,9 @@ rule "Editor | orb radi/strength":
     
     eventPlayer.LockEditor = true
     while eventPlayer.isHoldingButton(Button.ABILITY_2) and (eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isHoldingButton(Button.CROUCH)) :
-        if eventPlayer.EditModeSelection == 2 and len(eventPlayer.BounceIndex_Cache) > 0:
+        if eventPlayer.EditModeSelection == 2 and len(eventPlayer.BounceIndex_Cache):
             BounceStrength[EditSelected] += 0.1 if eventPlayer.isHoldingButton(Button.JUMP) else -0.1    
-        elif eventPlayer.EditModeSelection == 1 and len(eventPlayer.KillIndex_Cache) > 0:
+        elif eventPlayer.EditModeSelection == 1 and len(eventPlayer.KillIndex_Cache):
             KillBallRadii[EditSelected] +=  0.1 if eventPlayer.isHoldingButton(Button.JUMP) else -0.1
         wait(0.1)
     UpdateCache()
@@ -1165,7 +1165,7 @@ rule "Editor | select orb/portal":
     @Condition hostPlayer.EditorOn
     @Condition eventPlayer == hostPlayer
     @Condition eventPlayer.EditModeSelection in [1,2,4]
-    @Condition len(EditSelectIdArray) > 0
+    @Condition EditSelectIdArray != []
     @Condition eventPlayer.isHoldingButton(Button.INTERACT)
     @Condition eventPlayer.isHoldingButton(Button.CROUCH) or eventPlayer.isHoldingButton(Button.JUMP)
     #@Condition EditorMoveItem == false
@@ -1216,7 +1216,7 @@ rule "Editor | cp add/remove teleport":
         smallMessage(hostPlayer,"   关卡{0}的传送点已移除".format(hostPlayer.CurrentCheckpoint) checkCN "   Teleport for level {0} has been removed".format(hostPlayer.CurrentCheckpoint))
     else: # add
         CheckpointPositions[hostPlayer.CurrentCheckpoint] = [
-            CheckpointPositions[hostPlayer.CurrentCheckpoint][0] if len(CheckpointPositions[hostPlayer.CurrentCheckpoint]) != 0 else CheckpointPositions[hostPlayer.CurrentCheckpoint], 
+            CheckpointPositions[hostPlayer.CurrentCheckpoint][0] if len(CheckpointPositions[hostPlayer.CurrentCheckpoint]) else CheckpointPositions[hostPlayer.CurrentCheckpoint], 
             hostPlayer.getPosition()
         ]
         smallMessage(hostPlayer, "{1} {0}".format(hostPlayer.CurrentCheckpoint,"   传送点已添加到当前关卡" checkCN "   Teleport has been added for level"))
@@ -1230,7 +1230,7 @@ rule "Editor | moving checkpoint":
     @Condition eventPlayer == hostPlayer
     @Condition eventPlayer.EditModeSelection == 0
     @Condition eventPlayer.isHoldingButton(Button.ABILITY_2)
-    @Condition len(CheckpointPositions) > 0
+    @Condition CheckpointPositions != []
     @Condition eventPlayer.LockEditor == false
     wait(0.3, Wait.ABORT_WHEN_FALSE)
     
@@ -1253,7 +1253,7 @@ rule "Editor | add ult/dash":
     @Condition hostPlayer.EditorOn
     @Condition eventPlayer == hostPlayer    
     @Condition hostPlayer.EditModeSelection == 0
-    @Condition len(CheckpointPositions) > 0
+    @Condition CheckpointPositions != []
     @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE)
     @Condition eventPlayer.isHoldingButton(Button.ULTIMATE)
     @Condition eventPlayer.LockEditor == false
@@ -1270,7 +1270,7 @@ rule "Editor | toggle bans":
     @Condition hostPlayer.EditorOn
     @Condition eventPlayer == hostPlayer    
     @Condition hostPlayer.EditModeSelection == 3
-    @Condition len(CheckpointPositions) > 0
+    @Condition CheckpointPositions != []
     @Condition eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) or eventPlayer.isHoldingButton(Button.SECONDARY_FIRE) or eventPlayer.isHoldingButton(Button.JUMP) or eventPlayer.isHoldingButton(Button.CROUCH)
     @Condition eventPlayer.isHoldingButton(Button.INTERACT) or eventPlayer.isHoldingButton(Button.ABILITY_2)
     @Condition eventPlayer.LockEditor == false
@@ -1308,7 +1308,7 @@ rule "Editor | portal cp change":
     @Condition hostPlayer.EditModeSelection == 4
     @Condition eventPlayer.isHoldingButton(Button.JUMP) 
     @Condition eventPlayer.isHoldingButton(Button.ABILITY_2) 
-    @Condition len(EditSelectIdArray) > 0
+    @Condition EditSelectIdArray != []
     #@Condition EditorMoveItem == false
     @Condition eventPlayer.LockEditor == false
 
@@ -1322,7 +1322,7 @@ rule "Editor | move object":
     @Condition eventPlayer == hostPlayer    
     @Condition eventPlayer.EditModeSelection in [1,2,4]
     @Condition EditorMoveItem or (eventPlayer.isHoldingButton(Button.PRIMARY_FIRE) and eventPlayer.isHoldingButton(Button.ABILITY_2) and eventPlayer.LockEditor == false)
-    @Condition len(EditSelectIdArray) > 0
+    @Condition EditSelectIdArray != []
     eventPlayer.LockEditor = true
     EditorMoveItem = true
     if eventPlayer.flytoggle == null:

--- a/genji.opy
+++ b/genji.opy
@@ -512,6 +512,7 @@ def checkpointFailReset():
     eventPlayer.splittime = eventPlayer.practicetimer if eventPlayer.PracticeToggle else eventPlayer.Timer
     eventPlayer.LockCollected = []
     eventPlayer.cancelPrimaryAction()
+    eventPlayer.DoubleUsed = null
     eventPlayer.applyImpulse(Vector.DOWN, eventPlayer.getSpeed(), Relativity.TO_PLAYER, Impulse.CANCEL_CONTRARY_MOTION)
     eventPlayer.setStatusEffect(null, Status.ROOTED, 0.1)
 
@@ -876,6 +877,7 @@ rule "AFK timer":
     waitUntil(eventPlayer.isOnWall(), 2)
     if eventPlayer.isOnWall(): # prevent save bhop climb
         eventPlayer.cancelPrimaryAction() 
+        eventPlayer.DoubleUsed = null
 
     if RULE_CONDITION:
         goto RULE_START

--- a/genji.opy
+++ b/genji.opy
@@ -556,7 +556,7 @@ def StartGame_Sub():
         kill(eventPlayer, null)
        
     if len(CheckpointPositions):
-        destroyInWorldText(eventPlayer.TitleStore) # restarting reset t itle even if non on cp 0
+        destroyInWorldText(eventPlayer.TitleStore) # restarting reset title even if non on cp 0
         if "{0}".format(eventPlayer) in SaveName: # load saved progres
             SaveEnt[SaveName.index("{}".format(eventPlayer))] = eventPlayer
             eventPlayer.CurrentCheckpoint = SaveCp[SaveEnt.index(eventPlayer)]

--- a/genji.opy
+++ b/genji.opy
@@ -1,4 +1,4 @@
-#!define versionhere "1.9.4"
+#!define versionhere "1.9.4a"
 # cheats ##############################
 #!define editortoggle(x) __script__("test-maps/togglescript.js")
 editortoggle(0) # 0 is editor, rest is numbers

--- a/genji.opy
+++ b/genji.opy
@@ -234,9 +234,9 @@ rule "Setup and Variables":
     BounceToggleDash = BounceToggleDash if len(BounceToggleDash) else []
     BounceToggleLock = BounceToggleLock if len(BounceToggleLock) else []
 
-    CustomPortalStart = CustomPortalStart if len(CustomPortalStart) > 0 else [] 
-    CustomPortalEndpoint = CustomPortalEndpoint if len(CustomPortalEndpoint) > 0 else [] 
-    CustomPortalCP = CustomPortalCP if len(CustomPortalCP) > 0 else [] 
+    CustomPortalStart = CustomPortalStart if len(CustomPortalStart) else [] 
+    CustomPortalEndpoint = CustomPortalEndpoint if len(CustomPortalEndpoint) else [] 
+    CustomPortalCP = CustomPortalCP if len(CustomPortalCP) else [] 
 
     LeaderBoardFull = []
 
@@ -265,16 +265,16 @@ rule "Setup and Variables":
     wait(1) # add back to below wait if removed
     # clean out -1's after the ban has laoded
 
-    BanBhop = [i for i in BanBhop if i != -1] if len(BanBhop) > 0 else []
-    BanClimb = [i for i in BanClimb if i != -1] if len(BanClimb) > 0 else []
-    BanEmote = [i for i in BanEmote if i != -1] if len(BanEmote) > 0 else []
-    BanDead = [i for i in BanDead if i != -1] if len(BanDead) > 0 else []
-    BanCreate = [i for i in BanCreate if i != -1] if len(BanCreate) > 0 else []
-    BanMulti = [i for i in BanMulti if i != -1] if len(BanMulti) > 0 else []
-    BanTriple = null #[i for i in BanTriple if i != -1] if len(BanTriple) > 0 else [] # legacy code, now auto sets it to null to save space
-    BanStand = [i for i in BanStand if i != -1] if len(BanStand) > 0 else []
+    BanBhop = [i for i in BanBhop if i != -1] if len(BanBhop) else []
+    BanClimb = [i for i in BanClimb if i != -1] if len(BanClimb) else []
+    BanEmote = [i for i in BanEmote if i != -1] if len(BanEmote) else []
+    BanDead = [i for i in BanDead if i != -1] if len(BanDead) else []
+    BanCreate = [i for i in BanCreate if i != -1] if len(BanCreate) else []
+    BanMulti = [i for i in BanMulti if i != -1] if len(BanMulti) else []
+    BanTriple = null #[i for i in BanTriple if i != -1] if len(BanTriple) else [] # legacy code, now auto sets it to null to save space
+    BanStand = [i for i in BanStand if i != -1] if len(BanStand) else []
 
-    if len(PortalDest) > 0: # pre set control map portals. not in portal rule because shared I variable
+    if len(PortalDest): # pre set control map portals. not in portal rule because shared I variable
         for TempIterator1 in range(len(PortalLoc)):
             createEffect(
                 [i for i in getAllPlayers() if i.InvincibleToggle or not i.NotOnLastCp],
@@ -440,8 +440,6 @@ rule "Player Initialize":
     wait()
     StartGame_Sub()  # initialization of the game
     
-    
-
 def DeleteSave():
     @Name "delete save" 
     del SaveName[SaveEnt.index(eventPlayer)]
@@ -516,7 +514,7 @@ def checkpointFailReset():
     eventPlayer.applyImpulse(Vector.DOWN, eventPlayer.getSpeed(), Relativity.TO_PLAYER, Impulse.CANCEL_CONTRARY_MOTION)
     eventPlayer.setStatusEffect(null, Status.ROOTED, 0.1)
 
-    if len(CheckpointPositions) > 0:
+    if len(CheckpointPositions):
         eventPlayer.teleport( CheckpointPositions[eventPlayer.CurrentCheckpoint].last() )
 
     if eventPlayer.ban_dedhop and eventPlayer.InvincibleToggle == false and eventPlayer.NotOnLastCp:
@@ -547,7 +545,7 @@ def StartGame_Sub():
         kill(eventPlayer,null)
         return
     
-    if DashExploitToggle and len(CheckpointPositions)>0:
+    if DashExploitToggle and len(CheckpointPositions):
         eventPlayer.setAbility1Enabled(false)
         wait()
         if eventPlayer.isUsingAbility1():
@@ -557,7 +555,7 @@ def StartGame_Sub():
     if eventPlayer.isUsingUltimate():
         kill(eventPlayer, null)
        
-    if len(CheckpointPositions) != 0:
+    if len(CheckpointPositions):
         destroyInWorldText(eventPlayer.TitleStore) # restarting reset t itle even if non on cp 0
         if "{0}".format(eventPlayer) in SaveName: # load saved progres
             SaveEnt[SaveName.index("{}".format(eventPlayer))] = eventPlayer
@@ -717,8 +715,6 @@ rule "Kill Orb | Activate":
     @Condition (any([distance(i, eventPlayer) <= eventPlayer.KillRadii_Cache[eventPlayer.KillPosition_Cache.index(i)] for i in eventPlayer.KillPosition_Cache]))
     checkpointFailReset()
 
-
-
 rule "Bounce Ball / Orb | Activate":
     @Event eachPlayer
     @Condition eventPlayer.BouncePosition_Cache != []
@@ -772,7 +768,6 @@ rule "Bounce Ball / Orb | Activate":
 
     eventPlayer.bouncetouchedlast = -1
 
-
 /*
 death rule notes ( not death note)
 without wait it can crash server
@@ -784,7 +779,7 @@ rule "Death Reset":
     @Condition not eventPlayer.SpectateToggle
     @Condition not eventPlayer.CompDone
     eventPlayer.clearStatusEffect(Status.PHASED_OUT)
-    if len(CheckpointPositions) > 0:
+    if len(CheckpointPositions):
         eventPlayer.resurrect()
     else:
         eventPlayer.respawn()
@@ -882,7 +877,6 @@ rule "AFK timer":
     if RULE_CONDITION:
         goto RULE_START
 
-
 #!include "huds.opy"
 
 #!include "commands.opy"     
@@ -962,8 +956,6 @@ rule "Credits and Colors here - 作者代码HUD颜色 <---- INSERT HERE / 在这
     #portals   -   自定义 传送门
     ColorConfig[customize.portal] = Color.WHITE
 
-
-
 rule "instructions depricated rules (ban / portal / dash /ult) - 旧版编辑器中已弃用规则指引 (单关封禁 / 传送门 / 给刀给S)":
     @Delimiter
     printLog("----------------")
@@ -1032,4 +1024,4 @@ rule "Comp Mode instruction message - 竞赛模式指引消息 <---- INSERT HERE
 #!include "addons-page2.opy"
 
 # enable/disable the include via defines
-testaitoggle 
+testaitoggle

--- a/genji.opy
+++ b/genji.opy
@@ -34,7 +34,7 @@ editortoggle(0) # 0 is editor, rest is numbers
 #!define bounceoffset + vect(0,0.7,0)
 
 
-#disable overpy map detection (command removed by zezo after fix by blizard)
+#disable overpy map detection (command removed by zezo after fix by blizzard)
 ##!disableMapDetectionFix 
 
 # supress warning for emote

--- a/huds.opy
+++ b/huds.opy
@@ -7,7 +7,6 @@ huds outside this file:
     - editor huds ( editor)
 
 */
-
 rule "Huds: Global/Localplayer":
     wait(2)
 
@@ -30,7 +29,6 @@ rule "Huds: Global/Localplayer":
     Code = null
 
     #  if Code != "code here - 代码" or Cachedcredits[1] == null::
-
 
     hudSubtext(getAllPlayers(), 
         "作者: {}".format( Cachedcredits[0] )
@@ -130,7 +128,6 @@ rule "Huds: Global/Localplayer":
             , HudPosition.TOP, HO.add_custommsg1, Color.BLUE, Color.BLUE, Color.BLUE, HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
         )
      
-  
     if CpIwtText != null:
         createInWorldText(
             getAllPlayers(), 
@@ -139,7 +136,7 @@ rule "Huds: Global/Localplayer":
             CpIwtPos[CpIwtCp.index(localPlayer.CurrentCheckpoint)], 
             2, Clip.SURFACES, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, CpIwtColor, SpecVisibility.DEFAULT)
 
-    if len(HintText) > 0:
+    if HintText != []:
         hudText(
             localPlayer if localPlayer.GuideToggle else null,
             null, 
@@ -252,8 +249,6 @@ rule "Huds: Global/Localplayer":
     #else:
         # restart without leaderboard if editor on
  
-
-
 rule "Huds: each player":
     @Event eachPlayer
     wait(0.5)
@@ -278,7 +273,6 @@ rule "Huds: each player":
         HudPosition.LEFT, HO.game_timer, ColorConfig[customize.time], Color.GRAY, ColorConfig[customize.time], HudReeval.STRING, SpecVisibility.DEFAULT
     )
     
-
     hudText(
         eventPlayer if not eventPlayer.LeaderboardToggle else null,  
         " {0} ({2}/{3})\n―――――――――――\n {1}\n"
@@ -401,8 +395,6 @@ rule "Huds: each player":
             , HudPosition.TOP, HO.comp_info, Color.YELLOW, Color.YELLOW, Color.YELLOW, HudReeval.STRING, SpecVisibility.DEFAULT
         ) 
 
-  
-  
 rule "Huds: remake leaderboard": # for global isntead of tied to player
     @Condition LeaderBoardRemake   
     wait() # account for delay in completion
@@ -534,7 +526,6 @@ rule "Huds: remake leaderboard": # for global isntead of tied to player
             ),HudPosition.TOP, HO.board_display4, Color.WHITE, HudReeval.VISIBILITY, SpecVisibility.DEFAULT
         )
         LeaderBoardHuds.append(getLastCreatedText())
-
 
 def UpdateTitle():
     @Name "Tittle "

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -200,13 +200,16 @@ rule "Checking | Double Jump":
         goto RULE_START
     if not eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP):
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
-    #Double Jumped
-    waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
-    if RULE_CONDITION:
-        goto RULE_START
-    eventPlayer.DoubleUsed = true
-    #CC refreshing Double Jump
-    #eventPlayer.DoubleUsed = false
+    while true:
+        #Double Jumped
+        waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        if RULE_CONDITION:
+            goto RULE_START
+        eventPlayer.DoubleUsed = true
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.DoubleUsed, 9999)
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        if RULE_CONDITION:
+            goto RULE_START
 
 rule "HUD | Multiclimb Counter":
     @Event eachPlayer

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -180,31 +180,28 @@ rule "Checking | Double Jump":
     @Event eachPlayer
     @Hero genji
     #Script by LulledLion
-    #9/1/24
     @Condition eventPlayer.isAlive() == true
     @Condition eventPlayer.isOnGround() == true
     
     eventPlayer.DoubleUsed = null
     #On Ground
     waitUntil(not eventPlayer.isOnGround(), 9999)
-    #Prehold Jump
-    if eventPlayer.isHoldingButton(Button.JUMP):
-        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
-        if RULE_CONDITION:
-            goto RULE_START
     #Saved Double Jump
     waitUntil(eventPlayer.isOnGround() or eventPlayer.isJumping() or eventPlayer.isHoldingButton(Button.JUMP), 0.096)
     if RULE_CONDITION:
         goto RULE_START
     if not eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP):
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+
+    waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+    if RULE_CONDITION:
+        goto RULE_START
     while true:
         #Double Jumped
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
         if RULE_CONDITION:
             goto RULE_START
         eventPlayer.DoubleUsed = true
-        #Double Reset
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.DoubleUsed, 9999)
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
         if RULE_CONDITION:

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -180,10 +180,8 @@ rule "Checking | Double Jump":
     @Event eachPlayer
     @Hero genji
     #Script by LulledLion
-    #08/28/24
+    #9/1/24
     @Condition eventPlayer.isAlive() == true
-    #TODO:
-    #CC refreshing Double Jump
     @Condition eventPlayer.isOnGround() == true
     
     eventPlayer.DoubleUsed = null
@@ -206,6 +204,7 @@ rule "Checking | Double Jump":
         if RULE_CONDITION:
             goto RULE_START
         eventPlayer.DoubleUsed = true
+        #Double Reset
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.DoubleUsed, 9999)
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
         if RULE_CONDITION:

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -113,11 +113,12 @@ rule "Checking | Using Emote":
     @Event eachPlayer
     @Condition eventPlayer.isCommunicatingEmote() == true
     eventPlayer.BhopUsed = false
-    waitUntil(not eventPlayer.isCommunicatingEmote() == true, 9999)
     if eventPlayer.ban_emote:
+        waitUntil(not eventPlayer.isCommunicatingEmote() == true, 9999)
         waitUntil(eventPlayer.isOnWall(), 1)
         if eventPlayer.isOnWall():
-            eventPlayer.cancelPrimaryAction() 
+            eventPlayer.cancelPrimaryAction()
+            eventPlayer.DoubleUsed = null
 
 rule "Checking | Bhop":
     @Event eachPlayer
@@ -174,7 +175,39 @@ rule "Checking | standing resets variables":
     if (eventPlayer.JumpCount != 0 or eventPlayer.WallclimbUsed) and eventPlayer.isOnGround():
         goto RULE_START
     eventPlayer.BhopUsed = true
-  
+
+rule "Checking | Double Jump":
+    @Event eachPlayer
+    @Hero genji
+    #Script by LulledLion
+    #08/28/24
+    @Condition eventPlayer.isAlive() == true
+    #TODO:
+    #CC refreshing Double Jump
+    @Condition eventPlayer.isOnGround() == true
+    
+    eventPlayer.DoubleUsed = null
+    #On Ground
+    waitUntil(not eventPlayer.isOnGround(), 9999)
+    #Prehold Jump
+    if eventPlayer.isHoldingButton(Button.JUMP):
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        if RULE_CONDITION:
+            goto RULE_START
+    #Saved Double Jump
+    waitUntil(eventPlayer.isOnGround() or eventPlayer.isJumping() or eventPlayer.isHoldingButton(Button.JUMP), 0.096)
+    if RULE_CONDITION:
+        goto RULE_START
+    if not eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP):
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+    #Double Jumped
+    waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
+    if RULE_CONDITION:
+        goto RULE_START
+    eventPlayer.DoubleUsed = true
+    #CC refreshing Double Jump
+    #eventPlayer.DoubleUsed = false
+
 rule "HUD | Multiclimb Counter":
     @Event eachPlayer
     @Condition eventPlayer.isOnWall()

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -94,6 +94,7 @@ rule "Checking | In the air":
     @Condition eventPlayer.isInAir() 
     eventPlayer.JumpCount = 1
 
+/* Remove this rule? */
 rule "Checking | Triple jump":
     @Event eachPlayer
     @Condition eventPlayer.JumpCount == 1

--- a/settings.opy
+++ b/settings.opy
@@ -68,8 +68,3 @@ settings {
 
 # no longer need dva
 ##!extension spawnMoreDummyBots
-
-
-
-
-

--- a/test-scripts.opy
+++ b/test-scripts.opy
@@ -12,7 +12,6 @@
 ##### average load show #####
     #!define avrgon true
     
-
 ##### orb visialize #####
     #!define orb_visialon false
 
@@ -50,16 +49,12 @@ globalvar AvrgMinStoreLen
 globalvar testAI
 globalvar AIcreated
 
-
-
-
 # temps ######################################################################################################################################################
 
 # general ######################################################################################################################################################
 
 rule "slowmo":
     setSlowMotion(slowmotion)
-
 
 rule "3th person cam":
     @Condition 3thpersoncam
@@ -86,8 +81,6 @@ rule "multi purpose hud":
         , HudPosition.LEFT, HO.leftend + 10, Color.LIME_GREEN, HudReeval.VISIBILITY_SORT_ORDER_STRING_AND_COLOR, SpecVisibility.DEFAULT
     )
 
-
-  
 # Load Calc ######################################################################################################################################################
 
 rule "server load hud":
@@ -124,7 +117,7 @@ rule "Avrg Seconds":
 
     AvrgSecDisplay = 0
     LastTimePeak = 0
-    while len(AvrgSecStore) > 0:
+    while len(AvrgSecStore):
         LastTimePeak = max(LastTimePeak,AvrgSecStore[0] )
         AvrgSecDisplay += AvrgSecStore[0]
         del AvrgSecStore[0]
@@ -175,7 +168,6 @@ rule "orbradiustest": # show radius on all bounce orbs
             EffectReeval.VISIBILITY_POSITION_RADIUS_AND_COLOR
         )
 
-
 rule "orbradiustest": # show player orb hit detection
     @Condition orb_visialon
     @Event eachPlayer
@@ -199,7 +191,6 @@ rule "leaderboard test bots":
         wait(0.1)
         testAI[len(testAI)-1].startForcingName("bot {0}".format(len(testAI)-1))
 
-        
     AIcreated = true
 
 rule "leaderboard test ai":
@@ -211,7 +202,6 @@ rule "leaderboard test ai":
     @Condition eventPlayer.CurrentCheckpoint < len(CheckpointPositions) #- 1
     @Condition (waitforcreate and AIcreated) or not waitforcreate
     
-
     if aistartdelay:
         wait(aiactiondelay )
 
@@ -271,7 +261,6 @@ rule "action test ai":
     wait()
     eventPlayer.stopForcingButton(Button.CROUCH)
     eventPlayer.stopForcingButton(Button.INTERACT)
-
 
 /*
 
@@ -370,7 +359,6 @@ rule "hud test":
 
     hudtestafafafg = true
 
-
 rule "each":
     @Event eachPlayer
     @Condition hudtestafafafg
@@ -445,6 +433,4 @@ rule "each":
         )
         wait()
         eventPlayer.sflkj ++
-
-
         */

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -1,5 +1,4 @@
 0.9 - date 17-8-2022
-
 - reworked A LOT of huds both visually and functionaly in both play mode and editor
 - removed unused extensions
 - fixed bugs with bans
@@ -23,7 +22,6 @@ editor:
 - editor rules via toggle instead
 - placing a teleport now puts a purple sphere down during editing that cp
 
-
 0.9.1 - date 18-8-2022
 added:
 - bounce orbs can now be used to lock checkpoints till collected
@@ -41,7 +39,6 @@ adjustments:
 - server restart time is now a smaller hud
 - the lobby should now autometically restart if the match is over
 - left top hud is now bigger
-
 
 0.9.2 - date 22-8-2022
 added:
@@ -116,7 +113,6 @@ fixed:
 Stable release
 - added Leaderboard on localplayer
 
-
 1.0.1 - date 12-9-2022
 - fixed orb selection not working properly
 - slowed down orb location editing
@@ -186,7 +182,6 @@ fixed:
 1.7.1 - ?
     - fixed ult start bug
     - some editor all player mesages are now only for host player
-
 
 1.7.2 - data 19-12-2022:
     - fake triple addon rule
@@ -297,7 +292,6 @@ fixed:
 1.8.2b
     - fixed a bug that allowed you to skip without practice mode on
 
-
 1.9 - 2-6-2023
 - preview now mentions ult,dash and bounce strength
 - you can now preview green orbs
@@ -328,8 +322,7 @@ editor:
     - a subroutine that triggers when arriving, failing, reseting or skipping etc
     - the stall orb addon
 
-- behind the scenes a lot of editor logistics have been reworked. for example selectinon now uses a global system instead of another system per mode.
-
+- behind the scenes a lot of editor logistics have been reworked. for example selection now uses a global system instead of another system per mode.
 
 1.9.1 - 13-6-2023
 - new addon: Hint per cp
@@ -346,14 +339,12 @@ if a player is stuck on a checkpoint they can press the hint button to see that 
 
 - temporary disabled Antarctica default control portals due to blizzard removing the map from the game
 
-
 1.9.1a - 22-7-2023
 - AFK timer now doesn't trigger when you are emoting. (and emote resets the timer)
 - fixed the mistake that caused the custom orb addon to only work for the host player
 
 1.9.1b - 29-7-2023
 - enabled antartica map in dva and control portals since it has been added back ingame
-
 
 1.9.2 - 12 - 10 - 2023
 additions
@@ -383,3 +374,7 @@ thanks to @junior for making this ban.
 
 fixed:
 - fixed a bug that caused Deathbhop ban to stop working
+
+1.9.4a
+- added a check for double jump
+- added a new addon to fix update 8-23-24 ledge grabs

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -379,7 +379,7 @@ fixed:
 - added a check for double jump
  └ added new variable "DoubleUsed"
  └ after each use of"CancelPrimaryAction()", reset "DoubleUsed" value
-- added a new addon to fix update 8-23-24 ledge grabs (default disabled)
+- added a new addon to fix ow update 2.12 on 8-23-24 for ledge grabs (default disabled)
  └ Has support for Hanzo & Kiriko (In-case someone needs it later)
  └ Known Issues: Heli/Vertical Multi-climb input timing is slower
 - Optimize ban emote

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -376,12 +376,13 @@ fixed:
 - fixed a bug that caused Deathbhop ban to stop working
 
 1.9.4a
-- added a check for double jump
+- Added a check for double jump
  └ added new variable "DoubleUsed"
  └ after each use of"CancelPrimaryAction()", reset "DoubleUsed" value
-- added a new addon to fix ow update 2.12 on 8-23-24 for ledge grabs (default disabled)
- └ Has support for Hanzo & Kiriko (In-case someone needs it later)
- └ Known Issues: Heli/Vertical Multi-climb input timing is slower
+X Added a new addon to fix ow update 2.12 for ledge grabs (default disabled)
+X└ Has support for Hanzo & Kiriko (In-case someone needs it later)
+X└ Known Issues: Heli/Vertical Multi-climb input timing is slower
+ └ Commented out for safe keeping, but do not compile
 - Optimize ban emote
 - Fix some comment typos and make line spacing more consistent
 - Append to the "ChangeLog" & "Known Issues"

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -377,4 +377,13 @@ fixed:
 
 1.9.4a
 - added a check for double jump
-- added a new addon to fix update 8-23-24 ledge grabs
+ └ added new variable "DoubleUsed"
+ └ after each use of"CancelPrimaryAction()", reset "DoubleUsed" value
+- added a new addon to fix update 8-23-24 ledge grabs (default disabled)
+ └ Has support for Hanzo & Kiriko (In-case someone needs it later)
+ └ Known Issues: Heli/Vertical Multi-climb input timing is slower
+- Optimize ban emote
+- Fix some comment typos and make line spacing more consistent
+- Append to the "ChangeLog" & "Known Issues"
+- Updated "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳"
+ └ Uses the new "DoubleUsed" for more accurate recreation of the original

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -1,16 +1,23 @@
+############################################################################################################
+multiple ledge grabs bug | introduced v2.12 8-23-24
+------------------------------------------------------------------------------------------------------------
+bug: After each successful ledge grab, ledge grab will snap player down.
+work arounds:
+- After each ledge grab, press & release jump before attempting another ledge grab
+- Addon "Ledge Grab Patch 1.4"
 
+Current known issues for "Ledge Grab Patch 1.4"
+-Requires slower input timings for heli/vertical multi-climb
+
+############################################################################################################
 bug: 
-- wallclimb baned can stil allow climb in some scenario, that one corner in ws chamber. maybe it was my latency?
+- wallclimb banned can stil allow climb in some scenario, that one corner in ws chamber. maybe it was my latency?
 - "if i bhop save and i use my double jump very close to the floor, and bhop is still green top left, and i hold space as im landing, my bhop just doesnt work" - arcane and confirmed by jack as all fw versions both old fw and our fw
 - spanvagyteso/jack: add custom restart point while in invinc mode and  reset to that instead, remove it when leaving invinc
 - multi climb sometimes stays green when not actually used  > maji: bind scrollwheel and spam
 
-
 multi indicator break: if you about to hit the floor as it about to give bhop and multi, you get bhop? or indicator only?
 multi break: auto climb on, flick wil say multi even if you climbing and lost it
-
-
-
 
 ############################################################################################################
 reload + cp position bug
@@ -45,7 +52,7 @@ triple jump ban doesnt work on workshop maps anymore
 
     - specific problem: jump count is not properly tracked. on ws maps jumpcount doesnt reset back to 1
         - on ws maps, the jumpcount doesnt go to 1 for a split second when triple jumping, unlike normal maps
-        - the rules for jupcount shouldnt be affected but they are
+        - the rules for jumpcount shouldnt be affected but they are
         - jumpcount tracks +- if a player has been in the air for a moment
 
 ############################################################################################################

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -1,6 +1,6 @@
 
 bug: 
-- walclimb baned can stil allow climb in some scenario, that one corner in ws chamber. maybe it was my latency?
+- wallclimb baned can stil allow climb in some scenario, that one corner in ws chamber. maybe it was my latency?
 - "if i bhop save and i use my double jump very close to the floor, and bhop is still green top left, and i hold space as im landing, my bhop just doesnt work" - arcane and confirmed by jack as all fw versions both old fw and our fw
 - spanvagyteso/jack: add custom restart point while in invinc mode and  reset to that instead, remove it when leaving invinc
 - multi climb sometimes stays green when not actually used  > maji: bind scrollwheel and spam

--- a/texts/known issues.txt
+++ b/texts/known issues.txt
@@ -1,10 +1,15 @@
 ############################################################################################################
-multiple ledge grabs bug | introduced v2.12 8-23-24
+Ledge Grab OW 2.12.*
 ------------------------------------------------------------------------------------------------------------
-bug: After each successful ledge grab, ledge grab will snap player down.
-work arounds:
+Delayed Mantle | OW 2.12.0.1
+Description: Client-side prediction renders genji's position & animation delayed when performing a mantle
+Work around: Touch grass
+
+(Patched) Multiple mantles snap down | OW 2.12.0.0
+Description: After each successful ledge grab, ledge grab will snap player down.
+Work arounds:
 - After each ledge grab, press & release jump before attempting another ledge grab
-- Addon "Ledge Grab Patch 1.4"
+- Addon "Ledge Grab Patch 1.5"
 
 Current known issues for "Ledge Grab Patch 1.4"
 -Requires slower input timings for heli/vertical multi-climb


### PR DESCRIPTION
1.9.4a
- Added a check for double jump
 └ added new variable "DoubleUsed"
 └ after each use of"CancelPrimaryAction()", reset "DoubleUsed" value
- X Added a new addon to fix ow update 2.12 for ledge grabs (default disabled)
X└ Has support for Hanzo & Kiriko (In-case someone needs it later)
X└ Known Issues: Heli/Vertical Multi-climb input timing is slower
  └ Commented out for safe keeping, but do not compile
- Optimize ban emote
- Fix some comment typos and make line spacing more consistent
- Append to the "ChangeLog" & "Known Issues"
- Updated "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳"
 └ Uses the new "DoubleUsed" for more accurate recreation of the original