### PR TITLE
1.10.0

### DIFF
--- a/addons-page2.opy
+++ b/addons-page2.opy
@@ -216,7 +216,7 @@ rule "Grup up | text/effect -":
     # replace vector 0,0,0 with orb position
     # 3.5 is the radius
     createEffect(
-        [i for i in getAllPlayers() if i.A == 777], 
+        [i for i in getAllPlayers() if i.CurrentCheckpoint == 777], 
         Effect.SPHERE, Color.ORANGE, vect(0,0,0),  3.5, EffectReeval.VISIBILITY
     )
 

--- a/commands.opy
+++ b/commands.opy
@@ -26,7 +26,7 @@ rule "Split hide":
     smallMessage(eventPlayer, "   split display off" if eventPlayer.splitdisplay == -999 else "   split display on")
     
 rule "Toggle Invisible | Hold Deflect":
-    @Condition false == disableInvisCommand
+    @Condition enableInvisCommand
     @Event eachPlayer
     @Condition eventPlayer.isHoldingButton(Button.ABILITY_2)
     @Condition not eventPlayer.EditorOn
@@ -204,7 +204,9 @@ rule "Enter Spectate | Hold Interact":
         stopChasingVariable(eventPlayer.Timer)
         eventPlayer.disableRespawn()
         wait(0.2)
+        eventPlayer.setDamageReceived(100)
         kill(eventPlayer, null)
+        eventPlayer.setDamageReceived(0)
         eventPlayer.teleport(CheckpointPositions[eventPlayer.CurrentCheckpoint].last())
  
     eventPlayer.SpectateToggle = not eventPlayer.SpectateToggle
@@ -250,11 +252,6 @@ rule "Toggle Invincible Mode | Melee + Reload":
         eventPlayer.flytoggle = null
         TriggerOnFailSuccesReset()
     else:
-        if not eventPlayer.NotOnLastCp:
-            wait()
-            eventPlayer.allowButton(Button.ABILITY_1)
-            eventPlayer.LockState = false
-            return
         StartPauseTimer()
         stopChasingVariable(eventPlayer.Timer)
         stopChasingVariable(eventPlayer.practicetimer)
@@ -271,7 +268,9 @@ rule "Toggle Invincible Mode | Melee + Reload":
         eventPlayer.allowButton(Button.ABILITY_1)
     wait()
     if eventPlayer.isUsingUltimate():
+        eventPlayer.setDamageReceived(100)
         kill(eventPlayer, null)
+        eventPlayer.setDamageReceived(0)
     eventPlayer.LockState = false
     wait(0.16)
     #waitUntil(not eventPlayer.isHoldingButton(Button.RELOAD), 2)
@@ -296,7 +295,9 @@ rule "Toggle Practice Mode | Melee + Ultimate":
     eventPlayer.disallowButton(Button.ABILITY_1)
 
     if eventPlayer.isUsingUltimate():
+        eventPlayer.setDamageReceived(100)
         kill(eventPlayer, null)
+        eventPlayer.setDamageReceived(0)
       
     wait(0.16)
     if eventPlayer.PracticeToggle:
@@ -360,7 +361,9 @@ rule "Practice Restart | Interact":
         return
     
     if eventPlayer.isUsingUltimate():
+        eventPlayer.setDamageReceived(100)
         kill(eventPlayer, null)
+        eventPlayer.setDamageReceived(0)
 
     eventPlayer.practicetimer = 0
     eventPlayer.splittime = 0 
@@ -419,31 +422,12 @@ rule "Quick Reset | Reload, Hold Reload to Enable":
     @Event eachPlayer
     @Condition eventPlayer.isHoldingButton(Button.RELOAD)
     @Condition not eventPlayer.isHoldingButton(Button.MELEE)
+    @Condition not eventPlayer.isHoldingButton(Button.INTERACT)
     if eventPlayer.QuickRestartToggle:
-        # lock check
-        # dont go 0,0,0 when no cps
-        if CheckpointPositions == [] or (eventPlayer.LockEditor and eventPlayer == hostPlayer):
-            return
-
-        if eventPlayer.EditorOn:
-            if eventPlayer == hostPlayer and eventPlayer.EditModeSelection == 0 and eventPlayer.isHoldingButton(Button.INTERACT):
-                wait(0.2)
-        eventPlayer.splittime = eventPlayer.practicetimer if eventPlayer.PracticeToggle else eventPlayer.Timer
-        eventPlayer.LockCollected = []
-        if eventPlayer.isUsingUltimate():
-            kill(eventPlayer, null)
-        eventPlayer.startForcingPosition(CheckpointPositions[eventPlayer.CurrentCheckpoint].last(), true)
         eventPlayer.flytoggle = null
-        async(CheckUlt(), AsyncBehavior.RESTART)
-        async(CheckDash(), AsyncBehavior.RESTART)
-        eventPlayer.teleport(CheckpointPositions[eventPlayer.CurrentCheckpoint].last())
-        wait(0.1)
         eventPlayer.stopForcingPosition()
-        if eventPlayer.CurrentCheckpoint == 0 and not eventPlayer.PracticeToggle:
-            eventPlayer.Timer = 0
-            eventPlayer.splittime = 0
-        eventPlayer.flytoggle = null
-        TriggerOnFailSuccesReset()
+        checkpointFailReset()
+
         wait(0.32)
     wait(1, Wait.ABORT_WHEN_FALSE)
     playEffect(eventPlayer, DynamicEffect.BUFF_IMPACT_SOUND, Color.WHITE, eventPlayer, 100)

--- a/commands.opy
+++ b/commands.opy
@@ -158,7 +158,7 @@ rule "Restart Run | Crouch + Interact + Deflect":
     if eventPlayer.isDead():
         eventPlayer.respawn()
 
-    StartGame_Sub()
+    StartGame()
     playEffect(eventPlayer, DynamicEffect.RING_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 100)
     wait()
     eventPlayer.allowButton(Button.ABILITY_1)

--- a/definitions.opy
+++ b/definitions.opy
@@ -50,7 +50,8 @@ globalvar CheckpointPositions 0             # list[vect | list[vect]]   --- some
 #globalvar SelectedCheckpoint_Editing       # legacy      # int                       --- selected checkpoint
 #!define CheckpointRings_Editing C
 globalvar CheckpointRings_Editing 2         # list[effect]              --- Holds checkpoint effects in editing context
-globalvar MsDestructo 3                     # MsDestructo Player
+#!define MapChecker MsDestructo
+globalvar MsDestructo 3                     # Player
 globalvar TimeRemaining 4
 globalvar PortalEffects 5                   # list[effect]              --- Array holding custom portal effects
 #globalvar CurrentPortalEditing
@@ -179,7 +180,7 @@ globalvar BanClimb 85
 globalvar BanBhop 86
 globalvar BanStand 87                       # bans on second hop
 globalvar BanDjump 88
-
+#!define MapCheckerIter DestructoIter
 globalvar DestructoIter 90
 globalvar MapVectorArray 91
 

--- a/definitions.opy
+++ b/definitions.opy
@@ -31,10 +31,10 @@ arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayn
     ]) else
 */
 
-#!define checkCN if l"Capture" == "捕捉" or l"Capture" == "捕捉" or "{0}".format(Color.ROSE) == "玫红" else
+##!define checkCN if l"Capture" == "捕捉" or l"Capture" == "捕捉" or "{0}".format(Color.ROSE) == "玫红" else
 # debug turn on cn
-##!define checkCN if true  else
-
+##!define checkCN if true else
+#!define checkCN if l"Oof" == "噢" else
 
 ##!define FILLER rule "Addon settings are on next page! Click the next page button!":\
 ##!define FILLER rule "Map data and addon settings are on page 2 !!!!!!!!!!!!!!!!!!!":\
@@ -122,46 +122,46 @@ arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayn
 #!define BhopHUDColor CH           
 
 
-# ----------------SUBS------------------
+#----------------SUBS------------------
 #!define StartGame_Sub Sub1
 ##!define KILLBALL KILLBALL
 ##!define pinball pinball
 
+#----------------Global Variables------------------
+# Warning do not change global variable indices.
+# Will result in variable mismatch upon exporting mapdata to newer versions
+# Current Unused Variables: 1,6,9,11,16,17,19,28,29,31,36,37,48,49,59,72,89,92+
 
-
-
-
-#Global variables
 globalvar CheckpointPositions 0             # list[vect | list[vect]]   --- sometimes nested - 0 original end, 1 teleported
-#globalvar SelectedCheckpoint_Editing 1 # legacy      # int                       --- selected checkpoint
+#globalvar SelectedCheckpoint_Editing       # legacy      # int                       --- selected checkpoint
 globalvar CheckpointRings_Editing 2         # list[effect]              --- Holds checkpoint effects in editing context
 globalvar MsDestructo 3                     # MsDestructo Player
 globalvar TimeRemaining 4
 globalvar PortalEffects 5                   # list[effect]              --- Array holding custom portal effects
-#globalvar CurrentPortalEditing 6
-#globalvar Portal1PlayerList 5               # list[player]              --- players who can see portal 1
-#globalvar Portal2PlayerList 6               # list[player]              --- players who can see portal 2
+#globalvar CurrentPortalEditing
+#globalvar Portal1PlayerList                # list[player]              --- players who can see portal 1
+#globalvar Portal2PlayerList                # list[player]              --- players who can see portal 2
 globalvar KillBallPositions 7               # list[vect]                --- KillBall position
 globalvar KillBallRadii 8                   # list[float]               --- KillBall radius, default 5
-#globalvar SelectedKillball_Editing 9        # int                       --- Current killball in editing context
+#globalvar SelectedKillball_Editing         # int                       --- Current killball in editing context
 globalvar KillBallEffects 10                # list[effect]              --- Array holding killball effects
-#globalvar KillBallChase 11                  # vect                      --- Location of killball while editing, chased.
+#globalvar KillBallChase                    # vect                      --- Location of killball while editing, chased.
 globalvar BladeEnabledCheckpoints 12        # int                       --- blade enabled, should be bool.
 globalvar DashEnabledCheckpoints 13         # int                       --- dash enabled, should be bool.
-#globalvar ListPlayersAtCheckpoints 15       # list[list[player]]        --- players at a specific checkpoint
-#globalvar ActivePlayers 16                  # list[player]              --- Active players, Non-saved, non-spectating active players
-#globalvar EditorOn 17                       # bool                      --- editor rules enabled?
+#globalvar ListPlayersAtCheckpoints         # list[list[player]]        --- players at a specific checkpoint
+#globalvar ActivePlayers                    # list[player]              --- Active players, Non-saved, non-spectating active players
+#globalvar EditorOn                         # bool                      --- editor rules enabled?
 globalvar EditSelected 14
 globalvar EditSelectIdArray 15
 
-#globalvar EditorMoveItem 16                          # num                       --- used for moving a portal
+#globalvar EditorMoveItem                   # num                       --- used for moving a portal
 
 #Bounce Pad editing stuff
 globalvar BouncePositions 18                # list[vect]                --- list of bouncepad positions
-#globalvar CurrentBounce_Editing 19          # int                       --- count of 0-indexed bouncepad pos currently
+#globalvar CurrentBounce_Editing            # int                       --- count of 0-indexed bouncepad pos currently
 globalvar BounceEffects 20                  # list[effects]             --- list of bounce pad effect entities
-#globalvar CurrentBouncePosition_Editing 21  # vect                      --- the position we just added to bouncepad positions
-globalvar EditorMoveItem 21                          # num                       --- used for moving a portal
+#globalvar CurrentBouncePosition_Editing    # vect                      --- the position we just added to bouncepad positions
+globalvar EditorMoveItem 21                 # num                       --- used for moving a portal
 
 globalvar BounceStrength 22                 # list[float]               --- bouncepad strength
 globalvar BounceToggleUlt 23                # list[bool]                --- toggle ult on bounce
@@ -175,9 +175,9 @@ globalvar BouncePadCheckpoints 27           # list[list[int]]           --- 2d l
 globalvar SavedProgress 30                  # list[Any]                 --- saves player data in array for rejoining, sequential data
 
 # Leaderboard stuff
-#globalvar toplistPlayers 32
-#globalvar toplistTimes 33
-#globalvar toplistSortedTimes 34
+#globalvar toplistPlayers
+#globalvar toplistTimes
+#globalvar toplistSortedTimes
 globalvar LeaderBoardFull 32                # [[name,second,prettytime]]--- sorted list of 0-19 leaderboard entries
 globalvar LeaderBoardHuds 33
 globalvar LeaderBoardRemake 34              # bool                      --- indicate board needs remaking
@@ -234,20 +234,21 @@ globalvar CpIwtCp 77
 globalvar CpIwtPos 78
 globalvar CpIwtColor 79
 
-globalvar BanTriple 80 # legacy
+globalvar BanTriple 80                      # legacy
 globalvar BanMulti 81
 globalvar BanCreate 82
 globalvar BanDead 83
 globalvar BanEmote 84
 globalvar BanClimb 85
 globalvar BanBhop 86
-globalvar BanStand 87 # bans on second hop
+globalvar BanStand 87                       # bans on second hop
+globalvar BanDjump 88
 
 globalvar DestructoIter 90
 globalvar MapVectorArray 91
 
-#Player variables
-playervar CurrentCheckpoint 0               # int                       --- Current Checkpoint
+#----------------Player Variables------------------
+playervar CurrentCheckpoint                 # int                       --- Current Checkpoint
 
 #PlayerEffects data
 #0 - Current ring, 
@@ -255,93 +256,93 @@ playervar CurrentCheckpoint 0               # int                       --- Curr
 #2 - Next lightshaft, 
 #3 - Next arrow icon, 
 #4 - Next "Come here" text
-#playervar PlayerEffects 1                   # list[effect]              --- Player effect data array  
-playervar InvincibleToggle 2                # bool                       --- invincible/normal mode toggle now a bool
-playervar Timer 3                           # float                     --- Timer, chased.
-playervar EditModeSelection 4               # int                       --- EditMode - 1 checkpoint | 2 Killing sphere | 3 Bouncing ball
-playervar SpectateToggle 5                  # bool                       --- turned into bool
-#playervar ArrayIterator 6                   # MsDestructo Iterator
-#playervar PortalText 7                      # In-World Text             --- Portal String inworld text
-#playervar MapVectorArray 8                  # MsDestructo Vectors
-playervar LedgeDash 6
-playervar LockEditor 7                      # bool                      --- ensure only 1 editor command can go of at the time
-playervar DontPlay
-playervar WallclimbUsed 9                   # bool                      --- turned into bool
-playervar GuideToggle 10                    # bool                       --- turned into bool, shows/hides editor hud
-playervar LockState 11                      # bool                      --- locked means you are curently runing arrive checkpoint rule
-playervar PauseTimer 12                     # float                     --- time in spectate/invincible, chased
-playervar Temp 13                           
-playervar BhopUsed 14                       # bool                      --- turned into bool
-playervar MovedCheckpoint 15
-playervar PracticeCheckpoint 16             # int                       --- Saved practice checkpoint
-playervar PracticeToggle 17                 # int                       --- turned into bool
-playervar LeaderboardToggle 19              # bool                      --- show/hide leaderboard
-playervar NotOnLastCp 20                    # bool                      --- false if you are noton the last cp or level below 2 cps
+#playervar PlayerEffects                    # list[effect]              --- Player effect data array  
+playervar InvincibleToggle                  # bool                       --- invincible/normal mode toggle now a bool
+playervar Timer                             # float                     --- Timer, chased.
+playervar EditModeSelection                 # int                       --- EditMode - 1 checkpoint | 2 Killing sphere | 3 Bouncing ball
+playervar SpectateToggle                    # bool                       --- turned into bool
+#playervar ArrayIterator                    # MsDestructo Iterator
+#playervar PortalText                       # In-World Text             --- Portal String inworld text
+#playervar MapVectorArray                   # MsDestructo Vectors
+playervar LedgeDash
+playervar LockEditor                        # bool                      --- ensure only 1 editor command can go of at the time
+playervar WallclimbUsed                     # bool                      --- turned into bool
+playervar GuideToggle                       # bool                       --- turned into bool, shows/hides editor hud
+playervar LockState                         # bool                      --- locked means you are curently runing arrive checkpoint rule
+playervar PauseTimer                        # float                     --- time in spectate/invincible, chased
+playervar Temp
+playervar BhopUsed                          # bool                      --- turned into bool
+playervar DoubleUsed                        # bool
+playervar MovedCheckpoint
+playervar PracticeCheckpoint                # int                       --- Saved practice checkpoint
+playervar PracticeToggle                    # int                       --- turned into bool
+playervar LeaderboardToggle                 # bool                      --- show/hide leaderboard
+playervar NotOnLastCp                       # bool                      --- false if you are noton the last cp or level below 2 cps
 playervar Bhopcount                         # int                       --- counts bhops used for stand create ban
-playervar JumpCount 26                      # int                       --- jump tracking count, 0, 1, 2
-playervar MultiClimbCountHUD 28             # HUD                       --- climb counter
-playervar CreateCounter 29
-playervar QuickRestartToggle 31             # bool                      -- enable reload to restart cp
-playervar MultiClimbCount 32                # int                       --- climb count # for HUD
-playervar finishfxcache  33                   # color                     --- color of fx after finish the map
-playervar HintsOn 34
-playervar PreviewsArray2 37
-playervar PreviewsArray 38                  # array                     --- store preview positions
-playervar PreviewsI 39                      # int                       --- preview itterator
-playervar invis 40                          # bool                      --- invis toggle added by fisho
-playervar flytoggle 41                      # vector/null               --- null if not flying, else vector position, added by fisho
-playervar savemaphud 42                     # array                     --- array of save map hud ids
-#playervar TracesOff 43                      # bool                      --- turn traces (ring explosion fx) off
-playervar EditorOn 45                       # bool                      --- on all players, but only gets checked from host player
-playervar LockCollected 46                  # number                    --- amount collected lock this cp
-playervar bouncetouched 47                  # int                       --- cache of the bouncepad id you are currently touching
-#playervar PortalLoop 48                     # int                       --- loop to select portal
-playervar PortalStart_Cache 48
-playervar BounceLockMax_Cache 49
-playervar KillPosition_Cache 50
-playervar KillRadii_Cache 51
-playervar BouncePosition_Cache 52
-playervar BounceStrength_Cache 53
-playervar BounceUlt_Cache 54
-playervar BounceDash_Cache 55
-playervar BounceLock_Cache 56
-playervar BounceIndex_Cache 57
-playervar KillIndex_Cache 58
-playervar bouncetouchedlast 59 
+playervar JumpCount                         # int                       --- jump tracking count, 0, 1, 2
+playervar MultiClimbCountHUD                # HUD                       --- climb counter
+playervar CreateCounter 
+playervar QuickRestartToggle                # bool                      -- enable reload to restart cp
+playervar MultiClimbCount                   # int                       --- climb count # for HUD
+playervar finishfxcache                     # color                     --- color of fx after finish the map
+playervar HintsOn
+playervar PreviewsArray2
+playervar PreviewsArray                     # array                     --- store preview positions
+playervar PreviewsI                         # int                       --- preview itterator
+playervar invis                             # bool                      --- invis toggle added by fisho
+playervar flytoggle                         # vector/null               --- null if not flying, else vector position, added by fisho
+playervar savemaphud                        # array                     --- array of save map hud ids
+#playervar TracesOff                        # bool                      --- turn traces (ring explosion fx) off
+playervar EditorOn                          # bool                      --- on all players, but only gets checked from host player
+playervar LockCollected                     # number                    --- amount collected lock this cp
+playervar bouncetouched                     # int                       --- cache of the bouncepad id you are currently touching
+#playervar PortalLoop                       # int                       --- loop to select portal
+playervar PortalStart_Cache
+playervar BounceLockMax_Cache
+playervar KillPosition_Cache
+playervar KillRadii_Cache
+playervar BouncePosition_Cache
+playervar BounceStrength_Cache
+playervar BounceUlt_Cache
+playervar BounceDash_Cache
+playervar BounceLock_Cache
+playervar BounceIndex_Cache
+playervar KillIndex_Cache
+playervar bouncetouchedlast
 
-playervar EffectSizeArray 60
-playervar EffectSizeToggle 61
-playervar CompDone 65                       # bool                      --- out of atemps or time?
-playervar AttemptCount 66                   # int                       --- amound of attemps remaining
-playervar instructionhud 67
-playervar TitleStore 68                     # textid                    --- store curent  title textid
+playervar EffectSizeArray
+playervar EffectSizeToggle
+playervar CompDone                          # bool                      --- out of atemps or time?
+playervar AttemptCount                      # int                       --- amound of attemps remaining
+playervar instructionhud
+playervar TitleStore                        # textid                    --- store curent  title textid
 
-playervar PortalEnd_cache 69
+playervar PortalEnd_cache
 
-playervar banstring 70                      # str                       --- displayed bans
-playervar ban_triple 71
-playervar ban_multi 72
-playervar ban_create 73
-playervar ban_dedhop 74
-playervar ban_dashstart 75
-playervar ban_emote 76
-playervar ban_climb 77
-playervar ban_bhop 78
-playervar ban_standcreate 81 # bans on second hop
-playervar splittime 79                      # int                       --- stored time that the split compares to
-playervar splitdisplay 80                   # int                       --- displayed split value
-#playervar splitson 81                      # bool                      --- turning splits on/off is now done via seting splittime to -999
-playervar practicetimer 82
+playervar banstring                         # str                       --- displayed bans
+playervar ban_triple
+playervar ban_multi
+playervar ban_create
+playervar ban_dedhop
+playervar ban_dashstart
+playervar ban_emote
+playervar ban_climb
+playervar ban_bhop
+playervar ban_standcreate                   # bans on second hop
+playervar ban_djump
+playervar splittime                         # int                       --- stored time that the split compares to
+playervar splitdisplay                      # int                       --- displayed split value
+#playervar splitson                         # bool                      --- turning splits on/off is now done via seting splittime to -999
+playervar practicetimer
 playervar ult_cd_global                     # int                       --- tracks cd for ult even if rule restarts the waits
-playervar BhopHUDColor 85                   # Color                     --- Color for Bhop HUD
-playervar DoubleUsed 86                     # bool
+playervar BhopHUDColor                      # Color                     --- Color for Bhop HUD
 
 #Subroutine names
-subroutine StartGame_Sub 1
-#subroutine KILLBALL 3
-#subroutine pinball 4
-#subroutine PortalCreate 5
-subroutine EffectsCreate 2
+subroutine StartGame_Sub
+#subroutine KILLBALL
+#subroutine pinball
+#subroutine PortalCreate
+subroutine EffectsCreate
 subroutine Leaderboardupdate # fishos
 subroutine CreateLeaderBoard
 subroutine UpdateTitle
@@ -369,6 +370,7 @@ enum HO:
     game_split_display,
     game_bhop,
     game_climb,
+    game_input,
 
     edit_orblimit,
     edit_selecteddata,

--- a/definitions.opy
+++ b/definitions.opy
@@ -3,7 +3,6 @@
 ##!define RestartTimer(timeInMinutes) "{0} Hours and {1} Minutes".format(floor(timeInMinutes / 60 / 60), "{0}{1}".format(floor(timeInMinutes % 60 / 10), floor(timeInMinutes % 60 - floor(timeInMinutes % 60 / 10) * 10)))
 ##!define prettyTime(timeInSeconds) "{0}:{1}".format(floor(timeInSeconds / 60), "{0}{1}.{2}".format(floor(timeInSeconds % 60 / 10), floor(timeInSeconds % 60 - floor(timeInSeconds % 60 / 10) * 10), "{0}{1}".format("" if floor((timeInSeconds % 1) * 100) >= 10 else "0", floor((timeInSeconds % 1) * 100))))
 ##!define prettyTime(timeInSeconds) "{0} sec".format(timeInSeconds)
-
 ##!define prettyTime(timeInSeconds) "{0} {1}".format(timeInSeconds,"秒"  checkCN "sec")
 #!define prettyTime(timeInSeconds) "{0} sec".format(timeInSeconds)
 
@@ -29,10 +28,9 @@ arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayn
         l"Capture" ==  "夺取",    # 捕捉cn \
         l"Capture" == "捕捉"  # 捕捉 tw  check \
     ]) else
+#!define checkCN if l"Capture" == "捕捉" or l"Capture" == "捕捉" or "{0}".format(Color.ROSE) == "玫红" else
 */
-
-##!define checkCN if l"Capture" == "捕捉" or l"Capture" == "捕捉" or "{0}".format(Color.ROSE) == "玫红" else
-# debug turn on cn
+# debug force CN mode on
 ##!define checkCN if true else
 #!define checkCN if l"Oof" == "噢" else
 
@@ -42,113 +40,41 @@ arrayname = [x - (1 if x >= hostPlayer.CurrentCheckpoint else 0) for x in arrayn
     @Delimiter\
     #@Disabled
 
-# ----------------GLOBAL------------------
-#!define CheckpointPositions A
-#!define SelectedCheckpoint_Editing B
-#!define CheckpointRings_Editing C 
-#3 MsDestructo
-#4 TimeRemaining
-#!define Portal1PlayerList F
-#!define Portal2PlayerList G
-#!define KillBallPositions H
-#!define KillBallRadii I
-#!define SelectedKillball_Editing J
-#!define KillBallEffects K
-#!define KillBallChase L
-#!define BladeEnabledCheckpoints Dao
-#!define DashEnabledCheckpoints SHIFT
-#14 O
-#!define ListPlayersAtCheckpoints P
-#!define ActivePlayers Q
-#17 R
-#Bounce Pad editing stuff
-#!define BouncePositions TQ
-#!define CurrentBounce_Editing TQ1
-#!define BounceEffects TQ2
-#!define CurrentBouncePosition_Editing TQ3
-#!define BounceStrength EditMode
-#!define BounceToggleUlt TQ5
-#!define BounceToggleDash TQ6
-
-#!define KillballCheckpoints killballnumber
-#!define BouncePadCheckpoints pinballnumber
-#!define DeathBhopBan deathjump
-#29
-#!define SavedProgress save
-##!define toplistPlayers toplistPlayers
-##!define toplistTimes toplistTimes
-##!define toplistSortedTimes toplistSortedTimes
-#!define BhopBanToggle kaxiaotiao
-#36
-#37
-#!define TempIterator1 NANBA
-
-
-# ----------------PLAYER------------------
-#!define CurrentCheckpoint A
-##!define PlayerEffects B
-#!define InvincibleToggle C
-#!define Timer D
-#!define EditModeSelection E
-#!define SpectateToggle F
-#6 ArrayIterator
-#!define PortalText H
-#8 MapVectorArray
-#!define WallclimbUsed J
-#!define GuideToggle K
-#11 L
-#!define PauseTimer ztjs
-#13
-#!define BhopUsed O
-#15
-#16 PracticeCheckpoint
-#17 PracticeToggle
-#18
-#!define LeaderboardTimerCapture T
-#20
-#21
-#22
-#23
-#24
-#25
-#!define JumpCount TY
-#27
-#!define MultiClimbCountHUD paqiang   
-#29
-#30
-#!define QuickRestartToggle quick_restart     
-#!define MultiClimbCount climbNum        
-           
-#!define BhopHUDColor CH           
-
-
-#----------------SUBS------------------
-#!define StartGame_Sub Sub1
-##!define KILLBALL KILLBALL
-##!define pinball pinball
-
 #----------------Global Variables------------------
 # Warning do not change global variable indices.
 # Will result in variable mismatch upon exporting mapdata to newer versions
 # Current Unused Variables: 1,6,9,11,16,17,19,28,29,31,36,37,48,49,59,72,89,92+
-
+#!define CheckpointPositions A
 globalvar CheckpointPositions 0             # list[vect | list[vect]]   --- sometimes nested - 0 original end, 1 teleported
+#!define SelectedCheckpoint_Editing B
 #globalvar SelectedCheckpoint_Editing       # legacy      # int                       --- selected checkpoint
+#!define CheckpointRings_Editing C
 globalvar CheckpointRings_Editing 2         # list[effect]              --- Holds checkpoint effects in editing context
 globalvar MsDestructo 3                     # MsDestructo Player
 globalvar TimeRemaining 4
 globalvar PortalEffects 5                   # list[effect]              --- Array holding custom portal effects
 #globalvar CurrentPortalEditing
+#!define Portal1PlayerList F
 #globalvar Portal1PlayerList                # list[player]              --- players who can see portal 1
+#!define Portal2PlayerList G
 #globalvar Portal2PlayerList                # list[player]              --- players who can see portal 2
+#!define KillBallPositions H
 globalvar KillBallPositions 7               # list[vect]                --- KillBall position
+#!define KillBallRadii I
 globalvar KillBallRadii 8                   # list[float]               --- KillBall radius, default 5
+#!define SelectedKillball_Editing J
 #globalvar SelectedKillball_Editing         # int                       --- Current killball in editing context
+#!define KillBallEffects K
 globalvar KillBallEffects 10                # list[effect]              --- Array holding killball effects
+#!define KillBallChase L
 #globalvar KillBallChase                    # vect                      --- Location of killball while editing, chased.
+#!define BladeEnabledCheckpoints Dao
 globalvar BladeEnabledCheckpoints 12        # int                       --- blade enabled, should be bool.
+#!define DashEnabledCheckpoints SHIFT
 globalvar DashEnabledCheckpoints 13         # int                       --- dash enabled, should be bool.
+#!define ListPlayersAtCheckpoints P
 #globalvar ListPlayersAtCheckpoints         # list[list[player]]        --- players at a specific checkpoint
+#!define ActivePlayers Q
 #globalvar ActivePlayers                    # list[player]              --- Active players, Non-saved, non-spectating active players
 #globalvar EditorOn                         # bool                      --- editor rules enabled?
 globalvar EditSelected 14
@@ -157,21 +83,29 @@ globalvar EditSelectIdArray 15
 #globalvar EditorMoveItem                   # num                       --- used for moving a portal
 
 #Bounce Pad editing stuff
+#!define BouncePositions TQ
 globalvar BouncePositions 18                # list[vect]                --- list of bouncepad positions
+#!define CurrentBounce_Editing TQ1
 #globalvar CurrentBounce_Editing            # int                       --- count of 0-indexed bouncepad pos currently
+#!define BounceEffects TQ2
 globalvar BounceEffects 20                  # list[effects]             --- list of bounce pad effect entities
+#!define CurrentBouncePosition_Editing TQ3
 #globalvar CurrentBouncePosition_Editing    # vect                      --- the position we just added to bouncepad positions
 globalvar EditorMoveItem 21                 # num                       --- used for moving a portal
-
+#!define BounceStrength EditMode
 globalvar BounceStrength 22                 # list[float]               --- bouncepad strength
+#!define BounceToggleUlt TQ5
 globalvar BounceToggleUlt 23                # list[bool]                --- toggle ult on bounce
+#!define BounceToggleDash TQ6
 globalvar BounceToggleDash 24               # list[bool]                --- toggle dash on bounce
 globalvar BounceToggleLock 25               # list[bool]                --- lock cp if not collected bounce
-
+#!define KillballCheckpoints killballnumber
 globalvar KillballCheckpoints 26            # list[list[int]]           --- 2d list of checkpoints that havea kill ball [[0], [3]]
+#!define BouncePadCheckpoints pinballnumber
 globalvar BouncePadCheckpoints 27           # list[list[int]]           --- 2d list like killballnumber
 
 # old save progresion, removed but kept in here for legacy pasta purposes
+#!define SavedProgress save
 globalvar SavedProgress 30                  # list[Any]                 --- saves player data in array for rejoining, sequential data
 
 # Leaderboard stuff
@@ -181,9 +115,10 @@ globalvar SavedProgress 30                  # list[Any]                 --- save
 globalvar LeaderBoardFull 32                # [[name,second,prettytime]]--- sorted list of 0-19 leaderboard entries
 globalvar LeaderBoardHuds 33
 globalvar LeaderBoardRemake 34              # bool                      --- indicate board needs remaking
+#!define BhopBanToggle kaxiaotiao
 globalvar BhopBanToggle 35                  # bool                      --- Enabled if Bhop is banned
 
-
+#!define TempIterator1 NANBA
 globalvar TempIterator1 38                  # int                       --- temp iterator
 
 globalvar DashExploitToggle 39
@@ -237,6 +172,7 @@ globalvar CpIwtColor 79
 globalvar BanTriple 80                      # legacy
 globalvar BanMulti 81
 globalvar BanCreate 82
+#!define deathjump BanDead
 globalvar BanDead 83
 globalvar BanEmote 84
 globalvar BanClimb 85
@@ -280,7 +216,7 @@ playervar LeaderboardToggle                 # bool                      --- show
 playervar NotOnLastCp                       # bool                      --- false if you are noton the last cp or level below 2 cps
 playervar Bhopcount                         # int                       --- counts bhops used for stand create ban
 playervar JumpCount                         # int                       --- jump tracking count, 0, 1, 2
-playervar MultiClimbCountHUD                # HUD                       --- climb counter
+#playervar MultiClimbCountHUD                # HUD                       --- climb counter
 playervar CreateCounter 
 playervar QuickRestartToggle                # bool                      -- enable reload to restart cp
 playervar MultiClimbCount                   # int                       --- climb count # for HUD
@@ -320,11 +256,11 @@ playervar TitleStore                        # textid                    --- stor
 playervar PortalEnd_cache
 
 playervar banstring                         # str                       --- displayed bans
-playervar ban_triple
+#playervar ban_triple
 playervar ban_multi
 playervar ban_create
 playervar ban_dedhop
-playervar ban_dashstart
+#playervar ban_dashstart
 playervar ban_emote
 playervar ban_climb
 playervar ban_bhop
@@ -338,7 +274,7 @@ playervar ult_cd_global                     # int                       --- trac
 playervar BhopHUDColor                      # Color                     --- Color for Bhop HUD
 
 #Subroutine names
-subroutine StartGame_Sub
+subroutine StartGame
 #subroutine KILLBALL
 #subroutine pinball
 #subroutine PortalCreate

--- a/editor.opy
+++ b/editor.opy
@@ -123,7 +123,7 @@ rule "Editor | Clear Excess Data to Save Map":
     eventPlayer.savemaphud[2] = getLastCreatedText()
 
     enableInspector()
-
+    disableInspector()
     waitUntil(not eventPlayer.isHoldingButton(Button.INTERACT), 9999)
     waitUntil(eventPlayer.isHoldingButton(Button.INTERACT), 9999)
     destroyHudText(eventPlayer.savemaphud[0])

--- a/genji.opy
+++ b/genji.opy
@@ -1,4 +1,4 @@
-#!define versionhere "1.9.5b"
+#!define versionhere "1.10.0"
 # cheats ##############################
 #!define editortoggle(x) __script__("test-maps/togglescript.js")
 editortoggle(0) # 0 is editor, rest is numbers
@@ -303,7 +303,7 @@ rule "Match time":
                 wait(0.032)
                 async(CreateLeaderBoard(), AsyncBehavior.RESTART)            
 
-    bigMessage(getAllPlayers(), "房间已达最大持续时间, 即将重启" checkCN "maximum lobby time expired, restarting")
+    bigMessage(localPlayer, "房间已达最大持续时间, 即将重启" checkCN "maximum lobby time expired, restarting")
     wait(5)
     if getCurrentGamemode() == Gamemode.FFA:
         declarePlayerVictory(hostPlayer)
@@ -312,6 +312,7 @@ rule "Match time":
 
 rule "Player Initialize":
     @Event playerJoined
+    @Condition eventPlayer.isDummy() == false
     eventPlayer.setDamageReceived(0)
     eventPlayer.EditorOn = createWorkshopSetting(bool, "map settings \n地图设置","Editor mode - 作图模式" ,  editoron , -1) # Turn Editor On
     eventPlayer.LockEditor = true
@@ -528,7 +529,7 @@ def StartGame():
 
 rule "Arrive | Ground reset | traces":
     @Event eachPlayer
-    #@Hero genji
+    @Condition eventPlayer.isDummy() == false
     @Condition eventPlayer.isOnGround()
     @Condition eventPlayer.isAlive()
     if eventPlayer.CurrentCheckpoint == len(CheckpointPositions) - 1:
@@ -716,8 +717,9 @@ this waituntil contrusction gives higher delay without relying on a variable cou
 */
 rule "Death Reset":
     @Event playerDied
-    @Condition not eventPlayer.SpectateToggle
-    @Condition not eventPlayer.CompDone
+    @Condition eventPlayer.isDummy() == false
+    @Condition eventPlayer.SpectateToggle == false
+    @Condition eventPlayer.CompDone == false
     if len(CheckpointPositions) > 0:
         eventPlayer.resurrect()
     else:

--- a/genji.opy
+++ b/genji.opy
@@ -360,7 +360,7 @@ rule "Player Initialize":
     
 
     wait()
-    StartGame_Sub()  # initialization of the game
+    StartGame()  # initialization of the game
     
 def DeleteSave():
     @Name "delete save" 
@@ -460,7 +460,7 @@ def checkpointFailReset():
     async(CheckDash(), AsyncBehavior.RESTART)
     TriggerOnFailSuccesReset()
 
-def StartGame_Sub():
+def StartGame():
     @Name "SUB | Start Game"
     if CompMode and (CompTime < 1 or eventPlayer.CompDone):
         eventPlayer.LeaderboardToggle = true

--- a/genji.opy
+++ b/genji.opy
@@ -1,4 +1,4 @@
-#!define versionhere "1.9.4a"
+#!define versionhere "1.9.5b"
 # cheats ##############################
 #!define editortoggle(x) __script__("test-maps/togglescript.js")
 editortoggle(0) # 0 is editor, rest is numbers
@@ -8,30 +8,30 @@ editortoggle(0) # 0 is editor, rest is numbers
 #!define inspectoron false
 
 # disable via double ## at include, not the define because the define needs to exist
-#!define testaitoggle ##!include "test-scripts.opy"
+#!define testToggle ##!include "test-scripts.opy"
 
 # enable to remove invis command (this command cant be pasted in cn client die to null and none translating to same symbol) 
-#!define disableInvisCommand false
+#!define enableInvisCommand true
 
+# defaults: off, attempt:5, 120 min, restart:false
 #!define compmodetoggle false
 #!define attemptcount 5
 #!define comptimelimit 120
 #!define comprestartlimit false
-# defaults: off, atempt:5, 120 min, restart:false
 
 # settings ##############################
 # limit on how many orbs can be made
 #!define fxlimit 193
 #!define portaldistance 1.3
 
-# 1.4 is the default cirkle radius, fx is default to 1
+# 1.4 is the default circle radius, fx is default to 1
 #!define cpcircleradius 1.4
 #!define cpcirklefx 1
 
 # distance range for player - orb 1.4
 #!define bounceorbdistance 1.4
-# eight added to player for orb detection. inludes the + 
-#!define bounceoffset + vect(0,0.7,0)
+# height added to player for orb detection. inludes the + 
+#!define bounceoffset + Vector.UP * 0.7
 
 
 #disable overpy map detection (command removed by zezo after fix by blizzard)
@@ -68,7 +68,7 @@ rule "------------------------------------------------------------------------  
 
 def UpdateCache():
     @Name "SUB | Update Effect Cache"
-    # note: if adding cp pos to cache, make sure to also adjsut editor things like move and teleport
+    # note: if adding cp pos to cache, make sure to also adjust editor things like move and teleport
     eventPlayer.NotOnLastCp = (eventPlayer.CurrentCheckpoint < len(CheckpointPositions) - 1 and len(CheckpointPositions)  > 1)
     
     eventPlayer.BouncePosition_Cache = [_ for _, i in BouncePositions if BouncePadCheckpoints[i] == eventPlayer.CurrentCheckpoint]
@@ -79,71 +79,43 @@ def UpdateCache():
     eventPlayer.BounceLockMax_Cache = len([i for i in eventPlayer.BounceLock_Cache if i])    
     eventPlayer.KillPosition_Cache = [_ for _, i in KillBallPositions if KillballCheckpoints[i] == eventPlayer.CurrentCheckpoint]
     eventPlayer.KillRadii_Cache = [_ for _, i in KillBallRadii if KillballCheckpoints[i] == eventPlayer.CurrentCheckpoint]
-    
     eventPlayer.PortalStart_Cache = [_ for _, i in CustomPortalStart if CustomPortalCP[i] == eventPlayer.CurrentCheckpoint or CustomPortalCP[i] == 999]
     eventPlayer.PortalEnd_cache = [_ for _, i in CustomPortalEndpoint if CustomPortalCP[i] == eventPlayer.CurrentCheckpoint or CustomPortalCP[i] == 999]
 
     eventPlayer.banstring = ""
     wait()
-
-    if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Multiclim - 封禁蹭留", false, 1):
-        eventPlayer.ban_multi = true
-    elif eventPlayer.CurrentCheckpoint in BanMulti:
+    eventPlayer.ban_multi = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Multiclimb - 封禁蹭留", false, 1) else eventPlayer.CurrentCheckpoint in BanMulti
+    if eventPlayer.ban_multi:
         eventPlayer.banstring = "∞ {}".format(eventPlayer.banstring)
-        eventPlayer.ban_multi = true
-    else:
-        eventPlayer.ban_multi = false
 
-    if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Createbhop - 封禁卡小", false, 2):
-        eventPlayer.ban_create = true
-    elif eventPlayer.CurrentCheckpoint in BanCreate:
+    eventPlayer.ban_create = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Createbhop - 封禁卡小", false, 2) else eventPlayer.CurrentCheckpoint in BanCreate
+    if eventPlayer.ban_create:
         eventPlayer.banstring = "♂ {}".format(eventPlayer.banstring)
-        eventPlayer.ban_create = true
-    else:
-        eventPlayer.ban_create = false
 
-    if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)","ban standcreate - 封禁站卡", false, 5):
-        eventPlayer.ban_standcreate = true
-    elif eventPlayer.CurrentCheckpoint in BanStand:
+    eventPlayer.ban_standcreate = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)","ban standcreate - 封禁站卡", false, 5) else eventPlayer.CurrentCheckpoint in BanStand
+    if eventPlayer.ban_standcreate:
         eventPlayer.banstring = "♠ {}".format(eventPlayer.banstring) # ≥  √ ▼ ↓
-        eventPlayer.ban_standcreate = true
-    else:
-        eventPlayer.ban_standcreate = false
 
-    if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Deathbhop - 封禁死小", false, 3):
-        eventPlayer.ban_dedhop = true
-    elif eventPlayer.CurrentCheckpoint in BanDead:
+    eventPlayer.ban_dedhop = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Deathbhop - 封禁死小", false, 3) else eventPlayer.CurrentCheckpoint in BanDead
+    if eventPlayer.ban_dedhop:
         eventPlayer.banstring = "X {}".format(eventPlayer.banstring)
-        eventPlayer.ban_dedhop = true
-    else:
-        eventPlayer.ban_dedhop = false
 
-    if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Emote Savehop - 封禁表情留小", false, 4):
-        eventPlayer.ban_emote = true
-    elif eventPlayer.CurrentCheckpoint in BanEmote:
+    eventPlayer.ban_emote = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Emote Savehop - 封禁表情留小", false, 4) else eventPlayer.CurrentCheckpoint in BanEmote
+    if eventPlayer.ban_emote:
         eventPlayer.banstring = "♥ {}".format(eventPlayer.banstring)
-        eventPlayer.ban_emote = true
-    else:
-        eventPlayer.ban_emote = false
-    
-    if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Wallclimb - 封禁爬墙", false, 5):
-        eventPlayer.ban_climb = true
-    elif eventPlayer.CurrentCheckpoint in BanClimb:
+
+    eventPlayer.ban_climb = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Wallclimb - 封禁爬墙", false, 5) else eventPlayer.CurrentCheckpoint in BanClimb
+    if eventPlayer.ban_climb:
         eventPlayer.banstring = "↑ {}".format(eventPlayer.banstring)
-        eventPlayer.ban_climb = true
-    else:
-        eventPlayer.ban_climb = false
 
-    if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)","require bhop available - 留小跳进点 ", false, 5):
-        eventPlayer.ban_bhop = true
-    elif eventPlayer.CurrentCheckpoint in BanBhop:
+    eventPlayer.ban_bhop = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)","require bhop available - 留小跳进点 ", false, 5) else eventPlayer.CurrentCheckpoint in BanBhop
+    if eventPlayer.ban_bhop:
         eventPlayer.banstring = "≥ {}".format(eventPlayer.banstring) # ≥  √ ▼ ↓
-        eventPlayer.ban_bhop = true
-    else:
-        eventPlayer.ban_bhop = false
 
+    eventPlayer.ban_djump = true if createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)","require djump available - 留二段跳 ", false, 5) else eventPlayer.CurrentCheckpoint in BanDjump
+    if eventPlayer.ban_djump:
+        eventPlayer.banstring = "» {}".format(eventPlayer.banstring) # ≥  √ ▼ ↓ ︽
 
- 
     wait()
     async(CheckUlt(), AsyncBehavior.RESTART)
     async(CheckDash(), AsyncBehavior.RESTART)
@@ -239,7 +211,6 @@ rule "Setup and Variables":
     CustomPortalCP = CustomPortalCP if len(CustomPortalCP) > 0 else [] 
 
     LeaderBoardFull = []
-
     TitleData = null
     PortalNames = []
     PortalLoc = []
@@ -249,6 +220,18 @@ rule "Setup and Variables":
     HintText = []
 
     wait(1)
+
+    # clean out -1's after the ban has loaded
+    BanBhop = [i for i in BanBhop if i != -1] if len(BanBhop) else []
+    BanClimb = [i for i in BanClimb if i != -1] if len(BanClimb) else []
+    BanEmote = [i for i in BanEmote if i != -1] if len(BanEmote) else []
+    BanDead = [i for i in BanDead if i != -1] if len(BanDead) else []
+    BanCreate = [i for i in BanCreate if i != -1] if len(BanCreate) else []
+    BanMulti = [i for i in BanMulti if i != -1] if len(BanMulti) else []
+    BanTriple = null #[i for i in BanTriple if i != -1] if len(BanTriple) > 0 else [] # legacy code, now auto sets it to null to save space
+    BanStand = [i for i in BanStand if i != -1] if len(BanStand) else []
+    BanDjump = BanDjump if len(BanDjump) else []
+
     DashExploitToggle = createWorkshopSetting(bool, "Ban (applies to all levels)\n封禁(应用于所有关卡)", "ban Dash Start - 0关卡Shift", true, 2)
     PortalOn = createWorkshopSetting(bool, "map settings \n地图设置","enable portals (control maps) - 启用传送门 (占点地图)",true, 10)
     CompMode = createWorkshopSetting(bool, "Competitive mode\n竞赛模式","Turn on competitive mode - 开启竞赛模式" , compmodetoggle , 100)
@@ -263,16 +246,6 @@ rule "Setup and Variables":
         instructiontext = null
 
     wait(1) # add back to below wait if removed
-    # clean out -1's after the ban has laoded
-
-    BanBhop = [i for i in BanBhop if i != -1] if len(BanBhop) > 0 else []
-    BanClimb = [i for i in BanClimb if i != -1] if len(BanClimb) > 0 else []
-    BanEmote = [i for i in BanEmote if i != -1] if len(BanEmote) > 0 else []
-    BanDead = [i for i in BanDead if i != -1] if len(BanDead) > 0 else []
-    BanCreate = [i for i in BanCreate if i != -1] if len(BanCreate) > 0 else []
-    BanMulti = [i for i in BanMulti if i != -1] if len(BanMulti) > 0 else []
-    BanTriple = null #[i for i in BanTriple if i != -1] if len(BanTriple) > 0 else [] # legacy code, now auto sets it to null to save space
-    BanStand = [i for i in BanStand if i != -1] if len(BanStand) > 0 else []
 
     if len(PortalDest) > 0: # pre set control map portals. not in portal rule because shared I variable
         for TempIterator1 in range(len(PortalLoc)):
@@ -325,6 +298,7 @@ rule "Match time":
                 getAllPlayers().CompDone = true
                 stopChasingVariable(getAllPlayers().Timer)
                 getAllPlayers().disableRespawn()
+                getAllPlayers().setDamageReceived(100)
                 kill(getAllPlayers(), null)
                 wait(0.032)
                 async(CreateLeaderBoard(), AsyncBehavior.RESTART)            
@@ -336,57 +310,11 @@ rule "Match time":
     else:
         declareTeamVictory(hostPlayer.getTeam())
 
-def EffectsCreate():
-    @Name "Effects Create"
-    if CustomPortalStart:
-        for TempIterator1 in range(len(CustomPortalStart)):
-            createEffect(
-                [i for i in getAllPlayers() if i.CurrentCheckpoint == CustomPortalCP[evalOnce(TempIterator1)] or CustomPortalCP[evalOnce(TempIterator1)] == 999],
-                Effect.GOOD_AURA, ColorConfig[customize.portal],
-                CustomPortalStart[evalOnce(TempIterator1)], 
-                0.6,
-                EffectReeval.VISIBILITY
-            )
-            wait()
-        wait(0.5)
-        
-    if KillBallPositions != []:
-        for TempIterator1 in range(0, len(KillBallPositions)):
-            createEffect([x for x in getAllPlayers().concat(null) if x.CurrentCheckpoint == KillballCheckpoints[evalOnce(TempIterator1)]], Effect.SPHERE, ColorConfig[customize.killorb] , KillBallPositions[evalOnce(TempIterator1)], KillBallRadii[evalOnce(TempIterator1)], EffectReeval.VISIBILITY)
-            wait()
-        wait(0.5)
-
-    if BouncePositions != []:
-        for TempIterator1 in range(0, len(BouncePositions)):
-            createEffect(
-                [x for x in getAllPlayers().concat(null) if x.CurrentCheckpoint == BouncePadCheckpoints[evalOnce(TempIterator1)] and not BouncePositions[evalOnce(TempIterator1)] in x.LockCollected], 
-                Effect.ORB, 
-                ColorConfig[customize.orb_lock] if BounceToggleLock[TempIterator1] else ColorConfig[customize.orb_normal] , 
-                BouncePositions[evalOnce(TempIterator1)], 
-                1, 
-                EffectReeval.VISIBILITY
-            )
-            wait()
-    
-    createEffect( # portal preview
-        localPlayer
-            if 
-            localPlayer.PreviewsI >= len(localPlayer.BouncePosition_Cache) + 1 and 
-            localPlayer.PreviewsI > 0 and
-            localPlayer.PreviewsArray2[localPlayer.PreviewsI][0] == 1 
-        else null
-        , 
-        Effect.SPARKLES,
-        Color.PURPLE,
-        localPlayer.PreviewsArray[localPlayer.PreviewsI], 
-        0.5, EffectReeval.VISIBILITY_POSITION_AND_RADIUS
-    )
 rule "Player Initialize":
-    @Event eachPlayer
+    @Event playerJoined
+    eventPlayer.setDamageReceived(0)
     eventPlayer.EditorOn = createWorkshopSetting(bool, "map settings \n地图设置","Editor mode - 作图模式" ,  editoron , -1) # Turn Editor On
     eventPlayer.LockEditor = true
-    if eventPlayer.isDummy() and eventPlayer.getCurrentHero() == Hero.DVA:
-        return # special here for dva instead of later because 100% she doesnt play the match
     eventPlayer.preloadHero(Hero.GENJI)
     eventPlayer.GuideToggle = true
     eventPlayer.disableGamemodeHud()
@@ -406,12 +334,6 @@ rule "Player Initialize":
     createEffect(eventPlayer if eventPlayer.NotOnLastCp  else null, Effect.RING, ColorConfig[customize.ring_next] , CheckpointPositions[eventPlayer.CurrentCheckpoint + 1], cpcirklefx, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
     createEffect(eventPlayer if eventPlayer.NotOnLastCp  else null, Effect.LIGHT_SHAFT, ColorConfig[customize.shaft], CheckpointPositions[eventPlayer.CurrentCheckpoint + 1], cpcirklefx, EffectReeval.VISIBILITY_POSITION_AND_RADIUS)
     createIcon(eventPlayer if eventPlayer.NotOnLastCp  else null, CheckpointPositions[eventPlayer.CurrentCheckpoint + 1] + Vector.UP, Icon.ARROW_DOWN, IconReeval.VISIBILITY_AND_POSITION, ColorConfig[customize.nexticon_color], true)
-    wait(1)  
-    if not eventPlayer.isDummy(): # players turn to genji
-        eventPlayer.startForcingHero(Hero.GENJI)
-    elif eventPlayer.getCurrentHero() != Hero.GENJI: # bots other then genji arent playing
-        eventPlayer.DontPlay = true
-        return
 
     waitUntil(eventPlayer.hasSpawned(), 9999)
     eventPlayer.LockEditor = false
@@ -440,8 +362,6 @@ rule "Player Initialize":
     wait()
     StartGame_Sub()  # initialization of the game
     
-    
-
 def DeleteSave():
     @Name "delete save" 
     del SaveName[SaveEnt.index(eventPlayer)]
@@ -531,7 +451,9 @@ def checkpointFailReset():
         eventPlayer.Timer = 0
         eventPlayer.splittime = 0
     if eventPlayer.isUsingUltimate():
+        eventPlayer.setDamageReceived(100)
         kill(eventPlayer, null)
+        eventPlayer.setDamageReceived(0)
         wait()
 
     async(CheckUlt(), AsyncBehavior.RESTART)
@@ -544,7 +466,9 @@ def StartGame_Sub():
         eventPlayer.LeaderboardToggle = true
         eventPlayer.CompDone = true
         eventPlayer.disableRespawn()
+        eventPlayer.setDamageReceived(100)
         kill(eventPlayer,null)
+        eventPlayer.setDamageReceived(0)
         return
     
     if DashExploitToggle and len(CheckpointPositions)>0:
@@ -555,7 +479,9 @@ def StartGame_Sub():
             smallMessage(eventPlayer,"   0关卡Shift已禁用!" checkCN "   Dash Start is banned!")            
 
     if eventPlayer.isUsingUltimate():
+        eventPlayer.setDamageReceived(100)
         kill(eventPlayer, null)
+        eventPlayer.setDamageReceived(0)
        
     if len(CheckpointPositions) != 0:
         destroyInWorldText(eventPlayer.TitleStore) # restarting reset title even if non on cp 0
@@ -590,8 +516,6 @@ def StartGame_Sub():
     
     eventPlayer.splittime = 0
     chase(eventPlayer.Timer, 9999999, rate=1, ChaseReeval.NONE)
-    eventPlayer.setStatusEffect(null, Status.PHASED_OUT, 9999)
-    eventPlayer.setStatusEffect(null, Status.INVINCIBLE, 9999)
     eventPlayer.LockCollected = []
     eventPlayer.InvincibleToggle = false
     eventPlayer.enableRespawn()
@@ -607,7 +531,6 @@ rule "Arrive | Ground reset | traces":
     #@Hero genji
     @Condition eventPlayer.isOnGround()
     @Condition eventPlayer.isAlive()
-    @Condition not eventPlayer.DontPlay
     if eventPlayer.CurrentCheckpoint == len(CheckpointPositions) - 1:
         
         if (eventPlayer.isMoving() and eventPlayer.PracticeToggle == false and eventPlayer.invis == false and eventPlayer.EditorOn == false and CompMode == false):
@@ -616,91 +539,99 @@ rule "Arrive | Ground reset | traces":
             #eventPlayer.finishfxcache =  rgb((cosDeg(getTotalTimeElapsed()/2 * 360 - 0) + 0.5) * 255, (cosDeg(getTotalTimeElapsed/2 * 360 - 120) + 0.5) * 255, (cosDeg(getTotalTimeElapsed/2 * 360 - 240) + 0.5) * 255)
             wait(0.16)
             # 1.6 - 0.2 in 0.2 steps
-            playEffect(getAllPlayers(), DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 1.4)
-            playEffect(getAllPlayers(), DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 1.2)
-            playEffect(getAllPlayers(), DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 1)
-            playEffect(getAllPlayers(), DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 0.8)
-            playEffect(getAllPlayers(), DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 0.6)
-            playEffect(getAllPlayers(), DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 0.4)
-            wait(0.128)     
-    elif eventPlayer.NotOnLastCp and eventPlayer.InvincibleToggle == false and (CompMode == false or CompTime > 0) and eventPlayer.LockState == false:
-        if distance(eventPlayer, CheckpointPositions[eventPlayer.CurrentCheckpoint + 1]) <= cpcircleradius:
-            # arrived ----------------------------------------------------------------------------------------------------
-            eventPlayer.MovedCheckpoint = true
-            if eventPlayer.BounceLockMax_Cache and len(eventPlayer.LockCollected) < eventPlayer.BounceLockMax_Cache: # kill player if not colleted the locks
-                if eventPlayer.isUsingAbility1():
-                    waitUntil(not eventPlayer.isUsingAbility1(), 1)    
-                smallMessage(eventPlayer, "   ! 进点前需集齐所有收集球 !" checkCN "   ! collect ALL {} orbs to unlock !".format(ColorConfig[customize.orb_lock]))
-                #kill(eventPlayer, null)
-                checkpointFailReset()
-                goto lbl_abc
-            if eventPlayer.ban_climb and eventPlayer.WallclimbUsed:
-                smallMessage(eventPlayer, "   爬墙 ↑ 已禁用!" checkCN "   Climb ↑ is banned!")
-                checkpointFailReset()
-                goto lbl_abc
-            
-            if eventPlayer.ban_bhop and not (eventPlayer.BhopUsed == 0 or eventPlayer.BhopHUDColor == Color.GREEN):
-                smallMessage(eventPlayer, "   ≥ 留小跳进点!" checkCN "   ≥ You need to have a bhop to complete!")
-                checkpointFailReset()
-                goto lbl_abc
-
-            #eventPlayer.LockCollected = []
-            eventPlayer.CurrentCheckpoint += 1
-            eventPlayer.HintsOn = false
-            UpdateCache()
-            # remove ult feature disabled for speedruning purposes
-            #if eventPlayer.isUsingUltimate() and not eventPlayer.CurrentCheckpoint in BladeEnabledCheckpoints:
-            #    kill(eventPlayer, null)
-            if len(CheckpointPositions[eventPlayer.CurrentCheckpoint]) > 1:# teleport cps
-                eventPlayer.startForcingPosition( CheckpointPositions[eventPlayer.CurrentCheckpoint].last() ,false)
-                eventPlayer.flytoggle = null
-                wait(0.1)
-                eventPlayer.stopForcingPosition()
-                # position wasnt ready when check cache ran
-                async(CheckUlt(), AsyncBehavior.RESTART)
-                async(CheckDash(), AsyncBehavior.RESTART)
-
-            
-            if eventPlayer.splitdisplay != -999:
-                eventPlayer.splitdisplay =  (eventPlayer.practicetimer if eventPlayer.PracticeToggle else eventPlayer.Timer) - eventPlayer.splittime
-            wait()
-            playEffect(eventPlayer, DynamicEffect.RING_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 100)
-            playEffect(eventPlayer if CompMode or eventPlayer.invis else getAllPlayers(), DynamicEffect.RING_EXPLOSION, Color.SKY_BLUE, CheckpointPositions[eventPlayer.CurrentCheckpoint] + vect(0, 1.5, 0), 4)
-            # msg disabled due to annoying new sound
-            #bigMessage(eventPlayer,  "{1} {0}".format(eventPlayer.CurrentCheckpoint, "抵达检查点" checkCN "Arrived at level")   )
-            wait()
-            UpdateTitle()
-            TriggerOnFailSuccesReset()
-           
-            if eventPlayer.PracticeToggle:
-                eventPlayer.splittime = eventPlayer.practicetimer
-                goto lbl_abc
-            
-            eventPlayer.splittime = eventPlayer.Timer
-            if eventPlayer.CurrentCheckpoint == len(CheckpointPositions) - 1 and (not eventPlayer.EditorOn) and (not eventPlayer.PracticeToggle): # complete lvl
-                stopChasingVariable(eventPlayer.Timer)
-                stopChasingVariable(eventPlayer.practicetimer) 
-                wait()
-                bigMessage(getAllPlayers(), "{0} {2} {1}".format(eventPlayer, prettyTime(eventPlayer.Timer),"已通关! 用时" checkCN "Mission complete! Time"))
-                   
-                DeleteSave()
-                Leaderboardupdate()
-                if CompMode and CompAtmpNum > 0:
-                    if eventPlayer.AttemptCount == CompAtmpNum: 
-                        CompAtmpSaveCount[CompAtmpSaveNames.index("{0}".format(eventPlayer))] = -1 
-                        eventPlayer.AttemptCount = -1                     
-                        eventPlayer.CompDone = true
-                        eventPlayer.LeaderboardToggle = true
-                        eventPlayer.disableRespawn()
-                        kill(eventPlayer,null)
-                    else:
-                        CompAtmpSaveCount[CompAtmpSaveNames.index("{0}".format(eventPlayer))] = eventPlayer.AttemptCount + 1
-            else: # update save
-                DeleteSave()
-                MakeSave()
-        elif distance(eventPlayer,CheckpointPositions[eventPlayer.CurrentCheckpoint].last()) > cpcircleradius and not touchground:
-            # ground reset ----------------------------------------------------------------------------------------------------
+            playEffect(localPlayer, DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 1.4)
+            playEffect(localPlayer, DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 1.2)
+            playEffect(localPlayer, DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 1)
+            playEffect(localPlayer, DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 0.8)
+            playEffect(localPlayer, DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 0.6)
+            playEffect(localPlayer, DynamicEffect.RING_EXPLOSION, eventPlayer.finishfxcache, eventPlayer.getPosition(), 0.4)
+            wait(0.128)
+    elif eventPlayer.InvincibleToggle or (CompMode and CompTime == 0) or eventPlayer.LockState:
+        # Do nothing
+    elif eventPlayer.NotOnLastCp and distance(eventPlayer, CheckpointPositions[eventPlayer.CurrentCheckpoint + 1]) <= cpcircleradius:
+        # arrived ----------------------------------------------------------------------------------------------------
+        eventPlayer.MovedCheckpoint = true
+        if eventPlayer.BounceLockMax_Cache and len(eventPlayer.LockCollected) < eventPlayer.BounceLockMax_Cache: # kill player if not colleted the locks
+            if eventPlayer.isUsingAbility1():
+                waitUntil(not eventPlayer.isUsingAbility1(), 1)    
+            smallMessage(eventPlayer, "   ! 进点前需集齐所有收集球 !" checkCN "   ! collect ALL {} orbs to unlock !".format(ColorConfig[customize.orb_lock]))
+            #kill(eventPlayer, null)
             checkpointFailReset()
+            goto lbl_abc
+        if eventPlayer.ban_climb and eventPlayer.WallclimbUsed:
+            smallMessage(eventPlayer, "   爬墙 ↑ 已禁用!" checkCN "   Climb ↑ is banned!")
+            checkpointFailReset()
+            goto lbl_abc
+        
+        if eventPlayer.ban_bhop and not (eventPlayer.BhopUsed == 0 or eventPlayer.BhopHUDColor == Color.GREEN):
+            smallMessage(eventPlayer, "   ≥ 留小跳进点!" checkCN "   ≥ Must have a bhop to complete!")
+            checkpointFailReset()
+            goto lbl_abc
+
+        if eventPlayer.ban_djump and not (eventPlayer.DoubleUsed == 0):
+            smallMessage(eventPlayer, "   » 留二段跳!" checkCN "   » Must have a double jump to complete!")
+            checkpointFailReset()
+            goto lbl_abc
+
+        #eventPlayer.LockCollected = []
+        eventPlayer.CurrentCheckpoint += 1
+        eventPlayer.HintsOn = false
+        UpdateCache()
+        # remove ult feature disabled for speedruning purposes
+        #if eventPlayer.isUsingUltimate() and not eventPlayer.CurrentCheckpoint in BladeEnabledCheckpoints:
+        #    kill(eventPlayer, null)
+        if len(CheckpointPositions[eventPlayer.CurrentCheckpoint]) > 1:# teleport cps
+            eventPlayer.startForcingPosition( CheckpointPositions[eventPlayer.CurrentCheckpoint].last() ,false)
+            eventPlayer.flytoggle = null
+            wait(0.1)
+            eventPlayer.stopForcingPosition()
+            # position wasnt ready when check cache ran
+            async(CheckUlt(), AsyncBehavior.RESTART)
+            async(CheckDash(), AsyncBehavior.RESTART)
+
+        
+        if eventPlayer.splitdisplay != -999:
+            eventPlayer.splitdisplay =  (eventPlayer.practicetimer if eventPlayer.PracticeToggle else eventPlayer.Timer) - eventPlayer.splittime
+        wait()
+        playEffect(eventPlayer, DynamicEffect.RING_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 100)
+        playEffect(eventPlayer if CompMode or eventPlayer.invis else getAllPlayers(), DynamicEffect.RING_EXPLOSION, Color.SKY_BLUE, CheckpointPositions[eventPlayer.CurrentCheckpoint] + vect(0, 1.5, 0), 4)
+        # msg disabled due to annoying new sound
+        #bigMessage(eventPlayer,  "{1} {0}".format(eventPlayer.CurrentCheckpoint, "抵达检查点" checkCN "Arrived at level")   )
+        wait()
+        UpdateTitle()
+        TriggerOnFailSuccesReset()
+        
+        if eventPlayer.PracticeToggle:
+            eventPlayer.splittime = eventPlayer.practicetimer
+            goto lbl_abc
+        
+        eventPlayer.splittime = eventPlayer.Timer
+        if eventPlayer.CurrentCheckpoint == len(CheckpointPositions) - 1 and (not eventPlayer.EditorOn) and (not eventPlayer.PracticeToggle): # complete lvl
+            stopChasingVariable(eventPlayer.Timer)
+            stopChasingVariable(eventPlayer.practicetimer) 
+            wait()
+            bigMessage(getAllPlayers(), "{0} {2} {1}".format(eventPlayer, prettyTime(eventPlayer.Timer),"已通关! 用时" checkCN "Mission complete! Time"))
+                
+            DeleteSave()
+            Leaderboardupdate()
+            if CompMode and CompAtmpNum > 0:
+                if eventPlayer.AttemptCount == CompAtmpNum: 
+                    CompAtmpSaveCount[CompAtmpSaveNames.index("{0}".format(eventPlayer))] = -1 
+                    eventPlayer.AttemptCount = -1                     
+                    eventPlayer.CompDone = true
+                    eventPlayer.LeaderboardToggle = true
+                    eventPlayer.disableRespawn()
+                    eventPlayer.setDamageReceived(100)
+                    kill(eventPlayer,null)
+                    eventPlayer.setDamageReceived(0)
+                else:
+                    CompAtmpSaveCount[CompAtmpSaveNames.index("{0}".format(eventPlayer))] = eventPlayer.AttemptCount + 1
+        else: # update save
+            DeleteSave()
+            MakeSave()
+    elif distance(eventPlayer,CheckpointPositions[eventPlayer.CurrentCheckpoint].last()) > cpcircleradius:
+        # ground reset ----------------------------------------------------------------------------------------------------
+        checkpointFailReset()
 
     lbl_abc:
     eventPlayer.LockCollected = []
@@ -741,8 +672,12 @@ rule "Bounce Ball / Orb | Activate":
 
     eventPlayer.bouncetouchedlast = eventPlayer.bouncetouched 
 
-    if eventPlayer.BounceStrength_Cache[eventPlayer.bouncetouched] != 0:
+    if eventPlayer.BounceStrength_Cache[eventPlayer.bouncetouched] > 0:
         eventPlayer.applyImpulse(Vector.UP, eventPlayer.BounceStrength_Cache[eventPlayer.bouncetouched], Relativity.TO_WORLD, Impulse.CANCEL_CONTRARY_MOTION)
+    elif eventPlayer.BounceStrength_Cache[eventPlayer.bouncetouched] < 0:
+        eventPlayer.cancelPrimaryAction()
+        eventPlayer.DoubleUsed = null
+        playEffect(eventPlayer, DynamicEffect.BUFF_EXPLOSION_SOUND, Color.WHITE, eventPlayer, 75)
 
     if eventPlayer.BounceUlt_Cache[eventPlayer.bouncetouched]:
         eventPlayer.setUltEnabled(true)
@@ -783,7 +718,6 @@ rule "Death Reset":
     @Event playerDied
     @Condition not eventPlayer.SpectateToggle
     @Condition not eventPlayer.CompDone
-    eventPlayer.clearStatusEffect(Status.PHASED_OUT)
     if len(CheckpointPositions) > 0:
         eventPlayer.resurrect()
     else:
@@ -795,35 +729,20 @@ rule "Death Reset":
     waitUntil(eventPlayer.isDead(), 1)
     if eventPlayer.isDead() and (not eventPlayer.SpectateToggle) and (not eventPlayer.CompDone):
         wait(0.16)
-        eventPlayer.clearStatusEffect(Status.PHASED_OUT)
         eventPlayer.resurrect()
         checkpointFailReset()
         waitUntil(eventPlayer.isAlive(), 1)
         waitUntil(eventPlayer.isDead(), 1)
         if eventPlayer.isDead() and (not eventPlayer.SpectateToggle) and (not eventPlayer.CompDone):
             wait(0.44)
-            eventPlayer.clearStatusEffect(Status.PHASED_OUT)
             eventPlayer.resurrect()
             checkpointFailReset()
             waitUntil(eventPlayer.isAlive(), 1)
             waitUntil(eventPlayer.isDead(), 1)
             if eventPlayer.isDead() and (not eventPlayer.SpectateToggle) and (not eventPlayer.CompDone):
                 wait(0.64)
-                eventPlayer.clearStatusEffect(Status.PHASED_OUT)
                 eventPlayer.resurrect()
                 checkpointFailReset()
-
-rule "Player Phase":
-    @Event eachPlayer
-    @Condition not eventPlayer.hasStatusEffect(Status.PHASED_OUT)
-    @Condition eventPlayer.isAlive()
-    if eventPlayer.hasStatusEffect(Status.INVINCIBLE): # delay if its for afk sleep
-        wait(0.16)
-    eventPlayer.setStatusEffect(null, Status.PHASED_OUT, 9999)
-    eventPlayer.setStatusEffect(null, Status.INVINCIBLE, 9999)
-    wait(1)
-    if RULE_CONDITION:
-        goto RULE_START
 
 rule "Player Leaves":
     @Event playerLeft
@@ -850,11 +769,6 @@ rule "AFK timer":
     @Condition not eventPlayer.EditorOn
     wait(300, Wait.ABORT_WHEN_FALSE)
 
-    # clear status to apply sleep, auto re-aply via normal aply rule
-    eventPlayer.clearStatusEffect(Status.PHASED_OUT)
-    wait()
-    eventPlayer.clearStatusEffect(Status.INVINCIBLE)
-    wait()
     eventPlayer.setStatusEffect(null, Status.ASLEEP, 9999)
       # raycast to prevent camera stuck on low wall
     eventPlayer.startCamera(
@@ -1032,4 +946,4 @@ rule "Comp Mode instruction message - 竞赛模式指引消息 <---- INSERT HERE
 #!include "addons-page2.opy"
 
 # enable/disable the include via defines
-testaitoggle 
+testToggle 

--- a/huds.opy
+++ b/huds.opy
@@ -32,7 +32,7 @@ rule "Huds: Global/Localplayer":
     #  if Code != "code here - 代码" or Cachedcredits[1] == null::
 
 
-    hudSubtext(getAllPlayers(), 
+    hudSubtext(localPlayer, 
         "作者: {}".format( Cachedcredits[0] )
         checkCN
         "Made by: {}".format( Cachedcredits[0] )
@@ -46,10 +46,10 @@ rule "Huds: Global/Localplayer":
         , HudPosition.LEFT, HO.data_code, ColorConfig[customize.credit_code] , HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
     )
     HudStoreEdit.append(getLastCreatedText())
-    hudSubtext(localPlayer if localPlayer.GuideToggle else null, "Discord: dsc.gg/genjiparkour", HudPosition.LEFT, HO.data_dsc, ColorConfig[customize.dsc], HudReeval.VISIBILITY, SpecVisibility.DEFAULT)   
+    hudSubtext(localPlayer.GuideToggle, "Discord: dsc.gg/genjiparkour", HudPosition.LEFT, HO.data_dsc, ColorConfig[customize.dsc], HudReeval.VISIBILITY, SpecVisibility.DEFAULT)   
    
     # global huds
-    hudSubheader(getAllPlayers(),
+    hudSubheader(localPlayer,
         "房间将在 {0} 分钟后重启 - V{1}{2}".format(
             TimeRemaining, versionhere,
             "\n错误: 已达到最大HUD数量上限" if getNumberOfTextIds() >= 128 else ""  
@@ -63,22 +63,22 @@ rule "Huds: Global/Localplayer":
     )
     
     # padding for custom hud display
-    hudSubtext(getAllPlayers(), "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nv", HudPosition.TOP, HO.fillermain, Color.ORANGE, HudReeval.VISIBILITY, SpecVisibility.DEFAULT)
+    hudSubtext(localPlayer, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nv", HudPosition.TOP, HO.fillermain, Color.ORANGE, HudReeval.VISIBILITY, SpecVisibility.DEFAULT)
     
-    hudSubtext(localPlayer if localPlayer.GuideToggle else null, 
+    hudSubtext(localPlayer.GuideToggle, 
         "{0} {1} | {2}".format( "" if localPlayer.QuickRestartToggle else "长按",buttonString(Button.RELOAD),"快速回点 | 启用" if localPlayer.QuickRestartToggle else "启用快速回点")
         checkCN
         "{0} {1} | {2}".format( "" if localPlayer.QuickRestartToggle else "Hold",buttonString(Button.RELOAD),"Quick reset" if localPlayer.QuickRestartToggle else "Enable Quick reset")
         , HudPosition.RIGHT, HO.com_quickres, ColorConfig[customize.command_normal], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
     )
 
-    hudSubtext(localPlayer if localPlayer.GuideToggle else null, 
+    hudSubtext(localPlayer.GuideToggle, 
         "{0} + {1} | 探点模式{2}".format(buttonString(Button.RELOAD), buttonString(Button.MELEE)," | 启用" if localPlayer.InvincibleToggle else "") 
         checkCN
         "{0} + {1} | Invincible{2}".format(buttonString(Button.RELOAD), buttonString(Button.MELEE)," | ON" if localPlayer.InvincibleToggle else "") 
         ,HudPosition.RIGHT, HO.com_invincible, evalOnce(ColorConfig[customize.command_highlight]) if localPlayer.InvincibleToggle else evalOnce(ColorConfig[customize.command_normal]), HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
     )
-    hudText(getAllPlayers(),
+    hudText(localPlayer,
         null,
         "{0}{1}{2}".format(
             abilityIconString(Hero.BAPTISTE, Button.ABILITY_2) if localPlayer.InvincibleToggle else "",
@@ -91,7 +91,7 @@ rule "Huds: Global/Localplayer":
         ,HudPosition.RIGHT, HO.com_displaytoggle, ColorConfig[customize.command_normal], ColorConfig[customize.command_normal], ColorConfig[customize.command_normal], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
     )
 
-    hudSubtext(localPlayer if localPlayer.GuideToggle else null,  
+    hudSubtext(localPlayer.GuideToggle,  
         "长按 {0} + {1} | 预览关卡".format(buttonString(Button.PRIMARY_FIRE),buttonString(Button.SECONDARY_FIRE))
         checkCN
         "Hold {0} + {1} | Preview cp".format(buttonString(Button.PRIMARY_FIRE),buttonString(Button.SECONDARY_FIRE))
@@ -108,7 +108,7 @@ rule "Huds: Global/Localplayer":
     HudStoreEdit.append(getLastCreatedText())
 
 
-    hudSubtext(getAllPlayers(), 
+    hudSubtext(localPlayer, 
         "" if localPlayer.splitdisplay == -999 else
         ("单关用时 {0}".format(localPlayer.splitdisplay) if not localPlayer.SpectateToggle else "")
         checkCN
@@ -120,7 +120,7 @@ rule "Huds: Global/Localplayer":
     CreateLeaderBoard()
 
     if CpHudText != null: # text per checkpoint  text per cp each
-        hudText(getAllPlayers(),
+        hudText(localPlayer,
             CpHudText[CpHudCp.index(localPlayer.CurrentCheckpoint)]
             if localPlayer.CurrentCheckpoint in CpHudCp and localPlayer.GuideToggle else "",
             ("(文本已隐藏)" if localPlayer.CurrentCheckpoint in CpHudCp and not localPlayer.GuideToggle else "")
@@ -133,15 +133,14 @@ rule "Huds: Global/Localplayer":
   
     if CpIwtText != null:
         createInWorldText(
-            getAllPlayers(), 
+            localPlayer, 
             CpIwtText[CpIwtCp.index(localPlayer.CurrentCheckpoint)]
             if localPlayer.CurrentCheckpoint in CpIwtCp else "",
             CpIwtPos[CpIwtCp.index(localPlayer.CurrentCheckpoint)], 
             2, Clip.SURFACES, WorldTextReeval.VISIBILITY_POSITION_AND_STRING, CpIwtColor, SpecVisibility.DEFAULT)
 
     if len(HintText) > 0:
-        hudText(
-            localPlayer if localPlayer.GuideToggle else null,
+        hudText(localPlayer.GuideToggle,
             null, 
             (
             "{0} ――  有可用提示―― {0}".format(iconString(Icon.HAPPY)) if localPlayer.CurrentCheckpoint in HintCp and localPlayer.HintsOn == false else 
@@ -188,13 +187,13 @@ rule "Huds: Global/Localplayer":
         hudHeader([i for i in getAllPlayers() if i.instructionhud],"                                   Press {0} to start                                ".format(buttonString(Button.INTERACT)), HudPosition.TOP, HO.comp_instructbottom, Color.WHITE, HudReeval.VISIBILITY_AND_STRING,SpecVisibility.DEFAULT)
                 
     elif not CompMode:
-        hudSubtext(localPlayer if localPlayer.GuideToggle else null, 
+        hudSubtext(localPlayer.GuideToggle, 
             "长按 {0} | 观战模式{1}".format(buttonString(Button.INTERACT)," | 启用" if localPlayer.SpectateToggle else "")
             checkCN
             "Hold {0} | Spectate{1}".format(buttonString(Button.INTERACT)," | ON" if localPlayer.SpectateToggle else "")
             , HudPosition.RIGHT, HO.com_spec, evalOnce(ColorConfig[customize.command_highlight]) if localPlayer.SpectateToggle else evalOnce(ColorConfig[customize.command_normal]), HudReeval.VISIBILITY_STRING_AND_COLOR, SpecVisibility.DEFAULT
         )
-        hudSubtext(localPlayer if localPlayer.GuideToggle else null, 
+        hudSubtext(localPlayer.GuideToggle, 
             "长按 {0} | 隐身模式{1}".format(buttonString(Button.ABILITY_2)," | 启用" if localPlayer.invis else "")
             checkCN
             "Hold {0} | invisible{1}".format(buttonString(Button.ABILITY_2)," | ON" if localPlayer.invis else "")
@@ -202,7 +201,7 @@ rule "Huds: Global/Localplayer":
         )
         HudStoreEdit.append(getLastCreatedText())
 
-        hudSubtext(localPlayer if localPlayer.GuideToggle else null,
+        hudSubtext(localPlayer.GuideToggle,
             "{0} + {1} | 练习模式{2}".format(buttonString(Button.ULTIMATE), buttonString(Button.MELEE), " | ({0})".format(localPlayer.PracticeCheckpoint) if localPlayer.PracticeToggle else "")
             checkCN
             "{0} + {1} | Practice{2}".format(buttonString(Button.ULTIMATE), buttonString(Button.MELEE), " | ({0})".format(localPlayer.PracticeCheckpoint) if localPlayer.PracticeToggle else "")
@@ -242,7 +241,7 @@ rule "Huds: Global/Localplayer":
 
     # restart + leaderboard
     # this is remade in editor to not include leaderboard
-    hudSubtext(localPlayer if localPlayer.GuideToggle else null, 
+    hudSubtext(localPlayer.GuideToggle, 
         "{0} + {1} + {2} | 重新开始\n长按 {3} | 完整成绩排名".format(buttonString(Button.CROUCH), buttonString(Button.ABILITY_2), buttonString(Button.INTERACT),buttonString(Button.MELEE)) 
         checkCN
         "{0} + {1} + {2} | Restart\nHold {3} | leaderboard".format(buttonString(Button.CROUCH), buttonString(Button.ABILITY_2), buttonString(Button.INTERACT),buttonString(Button.MELEE))
@@ -252,157 +251,6 @@ rule "Huds: Global/Localplayer":
     #else:
         # restart without leaderboard if editor on
  
-
-
-rule "Huds: each player":
-    @Event eachPlayer
-    wait(0.5)
-    if eventPlayer.isDummy() and eventPlayer.getCurrentHero() == Hero.DVA:
-        return 
-    
-    # ban icons in level
-    hudText(eventPlayer, null, 
-        /*
-        ("练习用时 {0}".format(prettyTime(eventPlayer.practicetimer)) if eventPlayer.PracticeToggle else "")
-        checkCN  
-        ("Practice Time {0}".format(prettyTime(eventPlayer.practicetimer)) if eventPlayer.PracticeToggle else "")
-        */
-        "{} {}".format("练习用时" checkCN "Practice Time",prettyTime(eventPlayer.practicetimer)) if eventPlayer.PracticeToggle else "",
-        # 19191
-        "{} {}".format("用时" checkCN "Time",prettyTime(eventPlayer.Timer)),
-        #checkCN  
-        #"Time {0}".format(prettyTime(eventPlayer.Timer)) ,
-        #"用时 {0}".format(prettyTime(eventPlayer.Timer))
-        #checkCN  
-        #"Time {0}".format(prettyTime(eventPlayer.Timer)) ,
-        HudPosition.LEFT, HO.game_timer, ColorConfig[customize.time], Color.GRAY, ColorConfig[customize.time], HudReeval.STRING, SpecVisibility.DEFAULT
-    )
-    
-
-    hudText(
-        eventPlayer if not eventPlayer.LeaderboardToggle else null,  
-        " {0} ({2}/{3})\n―――――――――――\n {1}\n"
-        "".format(
-            ("检查点" if eventPlayer.PreviewsI == 0 else "弹球" if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1  else "自定义传送门") checkCN
-            "checkpoint" if eventPlayer.PreviewsI == 0 else "orb" if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1  else "portal",
-            "{} {} {} {}".format(
-                abilityIconString(Hero.GENJI, Button.ULTIMATE) if BounceToggleUlt[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] else "",
-                abilityIconString(Hero.GENJI, Button.ABILITY_1) if BounceToggleDash[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] else "",
-                iconString(Icon.WARNING) if BounceToggleLock[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] else "",
-                iconString(Icon.ARROW_UP) if BounceStrength[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] > 0 else
-                iconString(Icon.ARROW_DOWN) if BounceStrength[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] < 0 else ""
-            #) if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1 and eventPlayer.PreviewsI > 0 else "", # [0:cp, 1-x:bounce, x-y:portal]
-            ) if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1 and eventPlayer.PreviewsI > 0 else
-
-            (
-                ("传送门 {} 入口 ".format(eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
-                if eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][0] == 0 else  
-                "传送门 {} 出口 ".format( eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
-                ) checkCN
-
-                "portal {} start ".format(eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
-                if eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][0] == 0 else 
-                "portal {} destination ".format(eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
-            
-            )
-            if eventPlayer.PreviewsI >= len(eventPlayer.BouncePosition_Cache) + 1 and eventPlayer.PreviewsI > 0 else "",
-
-
-            eventPlayer.PreviewsI + 1,
-            len(eventPlayer.PreviewsArray)
-        ) if eventPlayer.PreviewsArray != null else ""
-        ,    
-        "{2} {0} / {1}".format(
-            len(eventPlayer.LockCollected), 
-            eventPlayer.BounceLockMax_Cache,
-            "{0}球".format(ColorConfig[customize.orb_lock]) checkCN "{0} orbs".format(ColorConfig[customize.orb_lock])
-            #"收集球" checkCN "{0} orbs".format(ColorConfig[customize.orb_lock])
-        ) if eventPlayer.BounceLockMax_Cache and eventPlayer.PreviewsArray == null else ""
-        ,
-        "{3}{2}{4} {0} / {1}".format(
-            eventPlayer.CurrentCheckpoint, 
-            len(CheckpointPositions) - 1,
-            "\n" if eventPlayer.banstring else "",
-            eventPlayer.banstring if eventPlayer.banstring else "",
-            "关卡" checkCN "Level"
-        ) if eventPlayer.PreviewsArray == null else ""
-        ,   
-        HudPosition.TOP, HO.game_level_orb, ColorConfig[customize.level], ColorConfig[customize.orb_lock], ColorConfig[customize.level], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
-    )
-    # climb/bhop indicators
-    hudHeader(eventPlayer,         
-        #"爬墙已用{0}".format("" if eventPlayer.MultiClimbCount < 1 else " ({0})".format(eventPlayer.MultiClimbCount))
-        "{1}{0}".format(
-            "" if eventPlayer.MultiClimbCount < 1 else " ({0})".format(eventPlayer.MultiClimbCount),
-            "爬墙已用" if  eventPlayer.WallclimbUsed else "爬墙未用" # cn version text updates to say the status, unlike en
-        )
-        checkCN
-        "Climb{0}".format("" if eventPlayer.MultiClimbCount < 1 else " ({0})".format(eventPlayer.MultiClimbCount))
-        , HudPosition.LEFT, HO.game_climb, 
-        evalOnce(ColorConfig[customize.bhopclimb_used]) if eventPlayer.WallclimbUsed else evalOnce(ColorConfig[customize.bhopclimb_available]), 
-        HudReeval.STRING_AND_COLOR, SpecVisibility.DEFAULT
-    )
-    hudHeader(eventPlayer, 
-        ( # cn version text updates to say the status, unlike en version
-            "{0}{1}".format(
-                "小跳未用" if eventPlayer.BhopUsed == 0 or eventPlayer.BhopHUDColor == evalOnce(ColorConfig[customize.bhopclimb_available]) else "小跳已用",
-                "" if eventPlayer.CreateCounter < 1 else " ({0})".format(eventPlayer.CreateCounter)  
-            )  
-        ) 
-        checkCN 
-        "Bhop{0}".format(
-            "" if eventPlayer.CreateCounter < 1 else
-            " ({0})".format(eventPlayer.CreateCounter) 
-        )
-        , HudPosition.LEFT, HO.game_bhop, 
-        evalOnce(ColorConfig[customize.bhopclimb_available]) if eventPlayer.BhopUsed == 0 else eventPlayer.BhopHUDColor, 
-        HudReeval.STRING_AND_COLOR, SpecVisibility.DEFAULT
-    )
-    
-    createInWorldText(
-        #eventPlayer if eventPlayer.NotOnLastCp else null, 
-        eventPlayer if eventPlayer.NotOnLastCp and eventPlayer.GuideToggle else null, 
-        "{0} {1}".format(
-            iconString(Icon.WARNING),    
-            "先收集橙球" checkCN "collect orbs first"
-        ) if eventPlayer.BounceLockMax_Cache and len(eventPlayer.LockCollected) < eventPlayer.BounceLockMax_Cache else
-        "到这里来" checkCN "Come here",
-        CheckpointPositions[eventPlayer.CurrentCheckpoint + 1], 
-        1.5, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING,  ColorConfig[customize.cometext], SpecVisibility.DEFAULT
-    )
-    
-    wait(2.5)
-    if CompMode:
-        hudText(
-            eventPlayer, 
-            " ",
-            (
-                "! 比赛结束 !" if CompTime <= 0 else
-                "剩余时间: {0} 分钟{1}".format(
-                    CompTime, 
-                    "\n你没有尝试过" if eventPlayer.AttemptCount == -1 else
-                    "\n尝试 {0} / {1}".format(eventPlayer.AttemptCount, CompAtmpNum) if CompAtmpNum > 0 
-                    else "" 
-                )
-            )
-            checkCN
-            (
-                "! competition is over !" if CompTime <= 0 else
-                "time left: {0} min{1}".format(
-                    CompTime, 
-                    "\nYou are out of attemps" if eventPlayer.AttemptCount == -1 else
-                    "\nAttempt {0} / {1}".format(eventPlayer.AttemptCount, CompAtmpNum) if CompAtmpNum > 0 
-                    else "" 
-                )
-            ), 
-            ("竞赛模式" if CompTime > 0 else "竞赛模式\n\n\n")
-            checkCN
-            ("competitive mode" if CompTime > 0 else "competitive mode\n\n\n")
-            , HudPosition.TOP, HO.comp_info, Color.YELLOW, Color.YELLOW, Color.YELLOW, HudReeval.STRING, SpecVisibility.DEFAULT
-        ) 
-
-  
-  
 rule "Huds: remake leaderboard": # for global isntead of tied to player
     @Condition LeaderBoardRemake   
     wait() # account for delay in completion
@@ -414,7 +262,7 @@ rule "Huds: remake leaderboard": # for global isntead of tied to player
     
     # top 5
     if LeaderBoardFull[0]:
-        hudSubtext(getAllPlayers(),
+        hudSubtext(localPlayer,
             " \n{0} 排名前5 {0}".format(abilityIconString(Hero.GENJI,Button.PRIMARY_FIRE))
             checkCN
             " \n{0} Top 5 {0}".format(abilityIconString(Hero.GENJI,Button.PRIMARY_FIRE))
@@ -535,9 +383,208 @@ rule "Huds: remake leaderboard": # for global isntead of tied to player
         )
         LeaderBoardHuds.append(getLastCreatedText())
 
+def EffectsCreate():
+    @Name "Effects Create"
+    if CustomPortalStart:
+        for TempIterator1 in range(len(CustomPortalStart)):
+            createEffect(
+                [i for i in getAllPlayers() if i.CurrentCheckpoint == CustomPortalCP[evalOnce(TempIterator1)] or CustomPortalCP[evalOnce(TempIterator1)] == 999],
+                Effect.GOOD_AURA, ColorConfig[customize.portal],
+                CustomPortalStart[evalOnce(TempIterator1)], 
+                0.6,
+                EffectReeval.VISIBILITY
+            )
+            wait()
+        wait(0.5)
+        
+    if KillBallPositions != []:
+        for TempIterator1 in range(0, len(KillBallPositions)):
+            createEffect([x for x in getAllPlayers().concat(null) if x.CurrentCheckpoint == KillballCheckpoints[evalOnce(TempIterator1)]], Effect.SPHERE, ColorConfig[customize.killorb] , KillBallPositions[evalOnce(TempIterator1)], KillBallRadii[evalOnce(TempIterator1)], EffectReeval.VISIBILITY)
+            wait()
+        wait(0.5)
+
+    if BouncePositions != []:
+        for TempIterator1 in range(0, len(BouncePositions)):
+            createEffect(
+                [x for x in getAllPlayers().concat(null) if x.CurrentCheckpoint == BouncePadCheckpoints[evalOnce(TempIterator1)] and not BouncePositions[evalOnce(TempIterator1)] in x.LockCollected], 
+                Effect.ORB, 
+                ColorConfig[customize.orb_lock] if BounceToggleLock[TempIterator1] else ColorConfig[customize.orb_normal] , 
+                BouncePositions[evalOnce(TempIterator1)], 
+                1, 
+                EffectReeval.VISIBILITY
+            )
+            wait()
+
+    createEffect( # portal preview
+        localPlayer
+            if 
+            localPlayer.PreviewsI >= len(localPlayer.BouncePosition_Cache) + 1 and 
+            localPlayer.PreviewsI > 0 and
+            localPlayer.PreviewsArray2[localPlayer.PreviewsI][0] == 1 
+        else null
+        , 
+        Effect.SPARKLES,
+        Color.PURPLE,
+        localPlayer.PreviewsArray[localPlayer.PreviewsI], 
+        0.5, EffectReeval.VISIBILITY_POSITION_AND_RADIUS
+    )
+
+##############################################################################
+
+rule "Huds: each player":
+    @Event playerJoined
+    wait(0.5)
+    
+    # ban icons in level
+    hudText(eventPlayer, null, 
+        /*
+        ("练习用时 {0}".format(prettyTime(eventPlayer.practicetimer)) if eventPlayer.PracticeToggle else "")
+        checkCN  
+        ("Practice Time {0}".format(prettyTime(eventPlayer.practicetimer)) if eventPlayer.PracticeToggle else "")
+        */
+        "{} {}".format("练习用时" checkCN "Practice Time",prettyTime(eventPlayer.practicetimer)) if eventPlayer.PracticeToggle else "",
+        # 19191
+        "{} {}".format("用时" checkCN "Time",prettyTime(eventPlayer.Timer)),
+        #checkCN  
+        #"Time {0}".format(prettyTime(eventPlayer.Timer)) ,
+        #"用时 {0}".format(prettyTime(eventPlayer.Timer))
+        #checkCN  
+        #"Time {0}".format(prettyTime(eventPlayer.Timer)) ,
+        HudPosition.LEFT, HO.game_timer, ColorConfig[customize.time], Color.GRAY, ColorConfig[customize.time], HudReeval.STRING, SpecVisibility.DEFAULT
+    )
+    
+
+    hudText(
+        eventPlayer if not eventPlayer.LeaderboardToggle else null,  
+        " {0} ({2}/{3})\n―――――――――――\n {1}\n"
+        "".format(
+            ("检查点" if eventPlayer.PreviewsI == 0 else "弹球" if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1  else "自定义传送门") checkCN
+            "checkpoint" if eventPlayer.PreviewsI == 0 else "orb" if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1  else "portal",
+            "{} {} {} {}".format(
+                abilityIconString(Hero.GENJI, Button.ULTIMATE) if BounceToggleUlt[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] else "",
+                abilityIconString(Hero.GENJI, Button.ABILITY_1) if BounceToggleDash[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] else "",
+                iconString(Icon.WARNING) if BounceToggleLock[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] else "",
+                iconString(Icon.ARROW_UP) if BounceStrength[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] > 0 else
+                iconString(Icon.ARROW_DOWN) if BounceStrength[eventPlayer.PreviewsArray2[eventPlayer.PreviewsI]] < 0 else ""
+            #) if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1 and eventPlayer.PreviewsI > 0 else "", # [0:cp, 1-x:bounce, x-y:portal]
+            ) if eventPlayer.PreviewsI < len(eventPlayer.BouncePosition_Cache) + 1 and eventPlayer.PreviewsI > 0 else
+
+            (
+                ("传送门 {} 入口 ".format(eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
+                if eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][0] == 0 else  
+                "传送门 {} 出口 ".format( eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
+                ) checkCN
+
+                "portal {} start ".format(eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
+                if eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][0] == 0 else 
+                "portal {} destination ".format(eventPlayer.PreviewsArray2[eventPlayer.PreviewsI][1])
+            
+            )
+            if eventPlayer.PreviewsI >= len(eventPlayer.BouncePosition_Cache) + 1 and eventPlayer.PreviewsI > 0 else "",
+
+
+            eventPlayer.PreviewsI + 1,
+            len(eventPlayer.PreviewsArray)
+        ) if eventPlayer.PreviewsArray != null else ""
+        ,    
+        "{2} {0} / {1}".format(
+            len(eventPlayer.LockCollected), 
+            eventPlayer.BounceLockMax_Cache,
+            "{0}球".format(ColorConfig[customize.orb_lock]) checkCN "{0} orbs".format(ColorConfig[customize.orb_lock])
+            #"收集球" checkCN "{0} orbs".format(ColorConfig[customize.orb_lock])
+        ) if eventPlayer.BounceLockMax_Cache and eventPlayer.PreviewsArray == null else ""
+        ,
+        "{3}{2}{4} {0} / {1}".format(
+            eventPlayer.CurrentCheckpoint, 
+            len(CheckpointPositions) - 1,
+            "\n" if eventPlayer.banstring else "",
+            eventPlayer.banstring if eventPlayer.banstring else "",
+            "关卡" checkCN "Level"
+        ) if eventPlayer.PreviewsArray == null else ""
+        ,   
+        HudPosition.TOP, HO.game_level_orb, ColorConfig[customize.level], ColorConfig[customize.orb_lock], ColorConfig[customize.level], HudReeval.VISIBILITY_AND_STRING, SpecVisibility.DEFAULT
+    )
+
+    hudSubtext(eventPlayer,"{0}{1}{2}\n{3}{4}{5}".format(
+        "■" if eventPlayer.isHoldingButton(Button.JUMP) else "□", "▲" if eventPlayer.getThrottle().z > null else "△",
+        "●" if eventPlayer.isHoldingButton(Button.CROUCH) else "○", "◀" if eventPlayer.getThrottle().x > null else "◁",
+        "▼" if eventPlayer.getThrottle().z < null else "∇", "▶" if eventPlayer.getThrottle().x < null else "▷"),
+        HudPosition.LEFT, HO.game_input, evalOnce(ColorConfig[customize.time]),HudReeval.STRING, SpecVisibility.DEFAULT)
+
+    # climb/bhop indicators
+    hudHeader(eventPlayer,         
+        #"爬墙已用{0}".format("" if eventPlayer.MultiClimbCount < 1 else " ({0})".format(eventPlayer.MultiClimbCount))
+        "{1}{0}".format(
+            "" if eventPlayer.MultiClimbCount < 1 else " ({0})".format(eventPlayer.MultiClimbCount),
+            "爬墙已用" if  eventPlayer.WallclimbUsed else "爬墙未用" # cn version text updates to say the status, unlike en
+        )
+        checkCN
+        "Climb{0}".format("" if eventPlayer.MultiClimbCount < 1 else " ({0})".format(eventPlayer.MultiClimbCount))
+        , HudPosition.LEFT, HO.game_climb, 
+        evalOnce(ColorConfig[customize.bhopclimb_used]) if eventPlayer.WallclimbUsed else evalOnce(ColorConfig[customize.bhopclimb_available]), 
+        HudReeval.STRING_AND_COLOR, SpecVisibility.DEFAULT
+    )
+    hudHeader(eventPlayer, 
+        ( # cn version text updates to say the status, unlike en version
+            "{0}{1}".format(
+                "小跳未用" if eventPlayer.BhopUsed == 0 or eventPlayer.BhopHUDColor == evalOnce(ColorConfig[customize.bhopclimb_available]) else "小跳已用",
+                "" if eventPlayer.CreateCounter < 1 else " ({0})".format(eventPlayer.CreateCounter)  
+            )  
+        ) 
+        checkCN 
+        "Bhop{0}".format(
+            "" if eventPlayer.CreateCounter < 1 else
+            " ({0})".format(eventPlayer.CreateCounter) 
+        )
+        , HudPosition.LEFT, HO.game_bhop, 
+        evalOnce(ColorConfig[customize.bhopclimb_available]) if eventPlayer.BhopUsed == 0 else eventPlayer.BhopHUDColor, 
+        HudReeval.STRING_AND_COLOR, SpecVisibility.DEFAULT
+    )
+    
+    createInWorldText(
+        #eventPlayer if eventPlayer.NotOnLastCp else null, 
+        eventPlayer if eventPlayer.NotOnLastCp and eventPlayer.GuideToggle else null, 
+        "{0} {1}".format(
+            iconString(Icon.WARNING),    
+            "先收集橙球" checkCN "collect orbs first"
+        ) if eventPlayer.BounceLockMax_Cache and len(eventPlayer.LockCollected) < eventPlayer.BounceLockMax_Cache else
+        "到这里来" checkCN "Come here",
+        CheckpointPositions[eventPlayer.CurrentCheckpoint + 1], 
+        1.5, Clip.NONE, WorldTextReeval.VISIBILITY_POSITION_AND_STRING,  ColorConfig[customize.cometext], SpecVisibility.DEFAULT
+    )
+    
+    wait(2.5)
+    if CompMode:
+        hudText(
+            eventPlayer, 
+            " ",
+            (
+                "! 比赛结束 !" if CompTime <= 0 else
+                "剩余时间: {0} 分钟{1}".format(
+                    CompTime, 
+                    "\n你没有尝试过" if eventPlayer.AttemptCount == -1 else
+                    "\n尝试 {0} / {1}".format(eventPlayer.AttemptCount, CompAtmpNum) if CompAtmpNum > 0 
+                    else "" 
+                )
+            )
+            checkCN
+            (
+                "! competition is over !" if CompTime <= 0 else
+                "time left: {0} min{1}".format(
+                    CompTime, 
+                    "\nYou are out of attemps" if eventPlayer.AttemptCount == -1 else
+                    "\nAttempt {0} / {1}".format(eventPlayer.AttemptCount, CompAtmpNum) if CompAtmpNum > 0 
+                    else "" 
+                )
+            ), 
+            ("竞赛模式" if CompTime > 0 else "竞赛模式\n\n\n")
+            checkCN
+            ("competitive mode" if CompTime > 0 else "competitive mode\n\n\n")
+            , HudPosition.TOP, HO.comp_info, Color.YELLOW, Color.YELLOW, Color.YELLOW, HudReeval.STRING, SpecVisibility.DEFAULT
+        ) 
 
 def UpdateTitle():
-    @Name "Tittle "
+    @Name "Title"
     if TitleData == null or CompMode or eventPlayer.PracticeToggle or eventPlayer.EditorOn or (not eventPlayer.CurrentCheckpoint in TitleData[0]): 
         return
     destroyInWorldText(eventPlayer.TitleStore)

--- a/mechanics.opy
+++ b/mechanics.opy
@@ -172,41 +172,32 @@ rule "Checking | standing resets variables":
     eventPlayer.MultiClimbCount = 0
     eventPlayer.CreateCounter = 0
     eventPlayer.Bhopcount = 0
+    eventPlayer.DoubleUsed = null
     wait(0)
     if (eventPlayer.JumpCount != 0 or eventPlayer.WallclimbUsed) and eventPlayer.isOnGround():
         goto RULE_START
     eventPlayer.BhopUsed = true
 
 rule "Checking | Double Jump":
-    @Disabled
     @Event eachPlayer
     @Hero genji
+    @Condition evalOnce(len(BanDjump)) or eventPlayer.ban_djump
     @Condition eventPlayer.isAlive() == true
-    @Condition eventPlayer.isOnGround() == true
-    
-    eventPlayer.DoubleUsed = null
-    #On Ground
-    waitUntil(not eventPlayer.isOnGround(), 9999)
+    @Condition eventPlayer.isOnGround() == false
     #Saved Double Jump
     waitUntil(eventPlayer.isOnGround() or eventPlayer.isJumping() or eventPlayer.isHoldingButton(Button.JUMP), 0.096)
-    if RULE_CONDITION:
-        goto RULE_START
-    if not eventPlayer.isJumping() and eventPlayer.isHoldingButton(Button.JUMP):
-        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
-
-    waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
-    if RULE_CONDITION:
-        goto RULE_START
+    if not RULE_CONDITION: return
     while true:
+        #Released Jump
+        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
+        if not RULE_CONDITION: return
         #Double Jumped
         waitUntil(eventPlayer.isOnGround() or eventPlayer.isHoldingButton(Button.JUMP), 9999)
-        if RULE_CONDITION:
-            goto RULE_START
+        if not RULE_CONDITION: return
         eventPlayer.DoubleUsed = true
+        #Reset
         waitUntil(eventPlayer.isOnGround() or not eventPlayer.DoubleUsed, 9999)
-        waitUntil(eventPlayer.isOnGround() or not eventPlayer.isHoldingButton(Button.JUMP), 9999)
-        if RULE_CONDITION:
-            goto RULE_START
+        if not RULE_CONDITION: return
 
 rule "HUD | Multiclimb Counter":
     @Event eachPlayer

--- a/settings.opy
+++ b/settings.opy
@@ -65,5 +65,5 @@ settings {
 }
 
 # extensions
-
+#!extension spawnMoreDummyBots
 #!extension playMoreEffects

--- a/settings.opy
+++ b/settings.opy
@@ -8,7 +8,7 @@ settings {
     },
     "lobby": {
         "allowPlayersInQueue": true,
-        "enableMatchVoiceChat": true,
+        "enableMatchVoiceChat": false,
         "spectatorSlots": 3,
         "team1Slots": 11,
         "team2Slots": 0,
@@ -23,7 +23,9 @@ settings {
             ]
         },
         "tdm": {
-            "enabledMaps": [],
+            "enabledMaps": [
+                selectedmap
+            ],
             "gameLengthInMn": 15,
             "enableMercyRezKillCancel": false,
             "enableSelfInitiatedRespawn": false
@@ -65,11 +67,3 @@ settings {
 # extensions
 
 #!extension playMoreEffects
-
-# no longer need dva
-##!extension spawnMoreDummyBots
-
-
-
-
-

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -389,7 +389,7 @@ X└ Known Issues: Heli/Vertical Multi-climb input timing is slower
 - Updated "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳"
  └ Uses the new "DoubleUsed" for more accurate recreation of the original
 
-1.9.5b
+1.10.0
 Features
 - Input UI
 - Checkpoint can have Double Jump Required
@@ -397,16 +397,16 @@ Features
 - Global mechanics bans are visible in-game to player
 - Huds, improve FPS
  └ Local Player for commands
- └ Simplify chinese
+ └ Simplify Chinese
 Optimizations
 - Double Jump
  └ checks only if there is a checkpoint restriction
- └ removed an uneccessary check that caused server load issues
+ └ removed an unnecessary check that caused server load issues
 - Removed phased out & invincible status and related rules
 - Quick Reset, remove duplicate code.
-- Removed vestige of dva dummy destruct code
+- Removed vestige of Dva dummy destruct code
 - Disable Match Voice (we are all on the same team)
 - refactor effects to huds.opy
 Editor
- └ Remove teleport doesn't reset to checkpoint while in invincibilty mode
- └ Inspector is redisabled after exporting map data
+ └ Remove teleport doesn't reset to checkpoint while in invincibility mode
+ └ Inspector is re-disabled after exporting map data

--- a/texts/changelog.txt
+++ b/texts/changelog.txt
@@ -388,3 +388,25 @@ X└ Known Issues: Heli/Vertical Multi-climb input timing is slower
 - Append to the "ChangeLog" & "Known Issues"
 - Updated "Fake Triple Jump - enable rule - 启用此规则 - 假三段跳"
  └ Uses the new "DoubleUsed" for more accurate recreation of the original
+
+1.9.5b
+Features
+- Input UI
+- Checkpoint can have Double Jump Required
+- Negative bounce orbs give double jump
+- Global mechanics bans are visible in-game to player
+- Huds, improve FPS
+ └ Local Player for commands
+ └ Simplify chinese
+Optimizations
+- Double Jump
+ └ checks only if there is a checkpoint restriction
+ └ removed an uneccessary check that caused server load issues
+- Removed phased out & invincible status and related rules
+- Quick Reset, remove duplicate code.
+- Removed vestige of dva dummy destruct code
+- Disable Match Voice (we are all on the same team)
+- refactor effects to huds.opy
+Editor
+ └ Remove teleport doesn't reset to checkpoint while in invincibilty mode
+ └ Inspector is redisabled after exporting map data


### PR DESCRIPTION
1.10.0
Features
- Input UI
- Checkpoint can have Double Jump Required
- Negative bounce orbs give double jump
- Global mechanics bans are visible in-game to player
- Huds, improve FPS
 └ Local Player for commands
 └ Simplify Chinese
Optimizations
- Double Jump
 └ checks only if there is a checkpoint restriction
 └ removed an unnecessary check that caused server load issues
- Removed phased out & invincible status and related rules
- Quick Reset, remove duplicate code.
- Removed vestige of Dva dummy destruct code
- Disable Match Voice (we are all on the same team)
- refactor effects to huds.opy
Editor
 └ Remove teleport doesn't reset to checkpoint while in invincibility mode
 └ Inspector is re-disabled after exporting map data